### PR TITLE
기존 테스트 코드 리팩토링

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/major/domain/Major.java
+++ b/src/main/java/com/gobongbob/festamate/domain/major/domain/Major.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Major {
-    COMPUTER_SCIENCE("소프트웨어융합대학", "AI컴퓨터공학부"),
-    BUSINESS_ADMINISTRATION("소프트웨어융합대학", "경영학부"),
-    INDUSTRIAL_MANAGEMENT_INFORMATION("소프트웨어융합대학", "컴퓨터공학과");
+    COMPUTER_SCIENCE("소프트웨어경영대학", "AI컴퓨터공학부"),
+    BUSINESS_ADMINISTRATION("소프트웨어경영대학", "경영학부"),
+    INDUSTRIAL_MANAGEMENT_INFORMATION("소프트웨어경영대학", "컴퓨터공학과");
 
     /*
     추후 더 다양한 학과가 추가될 예정입니다.

--- a/src/test/java/com/gobongbob/festamate/common/builder/BuilderSupporter.java
+++ b/src/test/java/com/gobongbob/festamate/common/builder/BuilderSupporter.java
@@ -1,0 +1,24 @@
+package com.gobongbob.festamate.common.builder;
+
+import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BuilderSupporter {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    public MemberRepository memberRepository() {
+        return memberRepository;
+    }
+
+    public RoomRepository roomRepository() {
+        return roomRepository;
+    }
+}

--- a/src/test/java/com/gobongbob/festamate/common/builder/TestFixtureBuilder.java
+++ b/src/test/java/com/gobongbob/festamate/common/builder/TestFixtureBuilder.java
@@ -1,0 +1,29 @@
+package com.gobongbob.festamate.common.builder;
+
+import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.room.domain.Room;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestFixtureBuilder {
+
+    @Autowired
+    private BuilderSupporter bs;
+
+    public Member buildMember(Member member) {
+        return bs.memberRepository().save(member);
+    }
+
+    public void deleteMember(Member member) {
+        bs.memberRepository().delete(member);
+    }
+
+    public Room buildRoom(Room room) {
+        return bs.roomRepository().save(room);
+    }
+
+    public void deleteRoom(Room room) {
+        bs.roomRepository().delete(room);
+    }
+}

--- a/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
+++ b/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.common.fixture;
 import com.gobongbob.festamate.domain.major.domain.Major;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.member.dto.request.MemberCreateRequest;
 import java.util.List;
 
 public class MemberFixture {
@@ -31,6 +32,20 @@ public class MemberFixture {
                 MEMBER1(),
                 MEMBER2(),
                 MEMBER3()
+        );
+    }
+
+    public static MemberCreateRequest createMemberCreateRequest(Member member) {
+        return new MemberCreateRequest(
+                member.getName(),
+                member.getNickname(),
+                member.getStudentId(),
+                member.getLoginId(),
+                member.getLoginPassword(),
+                member.getPhoneNumber(),
+                member.getGender().getName(),
+                member.getMajor().getCollege(),
+                member.getMajor().getDepartment()
         );
     }
 

--- a/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
+++ b/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
@@ -6,7 +6,7 @@ import com.gobongbob.festamate.domain.member.domain.Member;
 
 public class MemberFixture {
 
-    public static Member createMember(
+    private static Member createMember(
             String nickname,
             String studentId,
             String loginId,
@@ -26,7 +26,7 @@ public class MemberFixture {
     }
 
     public static Member MEMBER1() {
-        return MemberFixture.createMember(
+        return createMember(
                 "testNickname1",
                 "202500001",
                 "testLoginId1",

--- a/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
+++ b/src/test/java/com/gobongbob/festamate/common/fixture/MemberFixture.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.common.fixture;
 import com.gobongbob.festamate.domain.major.domain.Major;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
+import java.util.List;
 
 public class MemberFixture {
 
@@ -25,13 +26,41 @@ public class MemberFixture {
                 .build();
     }
 
+    public static List<Member> createMembers() {
+        return List.of(
+                MEMBER1(),
+                MEMBER2(),
+                MEMBER3()
+        );
+    }
+
     public static Member MEMBER1() {
         return createMember(
                 "testNickname1",
                 "202500001",
                 "testLoginId1",
-                "01012345678",
+                "01011111111",
                 Major.COMPUTER_SCIENCE
+        );
+    }
+
+    public static Member MEMBER2() {
+        return createMember(
+                "testNickname2",
+                "202500002",
+                "testLoginId2",
+                "01022222222",
+                Major.BUSINESS_ADMINISTRATION
+        );
+    }
+
+    public static Member MEMBER3() {
+        return createMember(
+                "testNickname3",
+                "202500003",
+                "testLoginId3",
+                "01033333333",
+                Major.INDUSTRIAL_MANAGEMENT_INFORMATION
         );
     }
 }

--- a/src/test/java/com/gobongbob/festamate/common/fixture/RoomFixture.java
+++ b/src/test/java/com/gobongbob/festamate/common/fixture/RoomFixture.java
@@ -4,7 +4,6 @@ import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 public class RoomFixture {
@@ -22,11 +21,22 @@ public class RoomFixture {
     }
 
     public static List<Room> createRooms(Member member) {
-        List<Room> rooms = new ArrayList<>();
-        for (int i = 0; i < 3; i++) {
-            rooms.add(createRoom(2 * (i + 1), Gender.MALE, member));
-        }
+        return List.of(
+                ROOM1(member),
+                ROOM2(member),
+                ROOM3(member)
+        );
+    }
 
-        return rooms;
+    public static Room ROOM1(Member member) {
+        return createRoom(4, Gender.MALE, member);
+    }
+
+    public static Room ROOM2(Member member) {
+        return createRoom(6, Gender.FEMALE, member);
+    }
+
+    public static Room ROOM3(Member member) {
+        return createRoom(6, Gender.MALE, member);
     }
 }

--- a/src/test/java/com/gobongbob/festamate/common/fixture/RoomFixture.java
+++ b/src/test/java/com/gobongbob/festamate/common/fixture/RoomFixture.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.common.fixture;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,6 +26,17 @@ public class RoomFixture {
                 ROOM1(member),
                 ROOM2(member),
                 ROOM3(member)
+        );
+    }
+
+    public static RoomCreateRequest createRoomCreateRequest(Room room) {
+        return new RoomCreateRequest(
+                room.getHeadCount(),
+                room.getPreferredGender().getName(),
+                room.getOpenChatLink(),
+                room.getMeetingDateTime(),
+                room.getTitle(),
+                room.getContent()
         );
     }
 

--- a/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
@@ -31,17 +31,7 @@ class MemberServiceTest extends serviceSliceTest {
         void successCreateRoom() {
             // given
             Member member = MemberFixture.MEMBER1();
-            MemberCreateRequest request = new MemberCreateRequest(
-                    member.getName(),
-                    member.getNickname(),
-                    member.getStudentId(),
-                    member.getLoginId(),
-                    member.getLoginPassword(),
-                    member.getPhoneNumber(),
-                    member.getGender().getName(),
-                    member.getMajor().getCollege(),
-                    member.getMajor().getDepartment()
-            );
+            MemberCreateRequest request = MemberFixture.createMemberCreateRequest(member);
 
             // when
             Member createdMember = memberService.createMember(request);

--- a/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.gobongbob.festamate.domain.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.gobongbob.festamate.common.fixture.MemberFixture;
 import com.gobongbob.festamate.domain.member.domain.Member;
@@ -37,10 +38,13 @@ class MemberServiceTest extends serviceSliceTest {
             Member createdMember = memberService.createMember(request);
 
             // then
-            assertThat(createdMember.getNickname()).isEqualTo(member.getNickname());
-            assertThat(createdMember.getStudentId()).isEqualTo(member.getStudentId());
-            assertThat(createdMember.getLoginId()).isEqualTo(member.getLoginId());
-            assertThat(createdMember.getPhoneNumber()).isEqualTo(member.getPhoneNumber());
+            assertAll(
+                    () -> assertThat(createdMember.getId()).isNotNull(),
+                    () -> assertThat(createdMember.getNickname()).isEqualTo(member.getNickname()),
+                    () -> assertThat(createdMember.getStudentId()).isEqualTo(member.getStudentId()),
+                    () -> assertThat(createdMember.getLoginId()).isEqualTo(member.getLoginId()),
+                    () -> assertThat(createdMember.getPhoneNumber()).isEqualTo(member.getPhoneNumber())
+            );
         }
     }
 }

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -40,18 +40,10 @@ class RoomServiceTest extends serviceSliceTest {
         @DisplayName("모임방을 생성에 성공한다.")
         void successCreateRoom() {
             // given
-            Member member = MemberFixture.MEMBER1();
-            memberRepository.save(member);
+            Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
 
-            Room room = RoomFixture.createRoom(4, Gender.MALE, member);
-            RoomCreateRequest request = new RoomCreateRequest(
-                    room.getHeadCount(),
-                    room.getPreferredGender().getName(),
-                    room.getOpenChatLink(),
-                    room.getMeetingDateTime(),
-                    room.getTitle(),
-                    room.getContent()
-            );
+            Room room = testFixtureBuilder.buildRoom(RoomFixture.ROOM1(member));
+            RoomCreateRequest request = RoomFixture.createRoomCreateRequest(room);
 
             // when
             Room createdRoom = roomService.createRoom(request, member.getId());
@@ -70,44 +62,29 @@ class RoomServiceTest extends serviceSliceTest {
         @DisplayName("특정 모임방 단건 조회에 성공한다.")
         void successFindRoomById() {
             // given
-            Member member = MemberFixture.MEMBER1();
-            memberRepository.save(member);
-
-            Room room = RoomFixture.createRoom(4, Gender.MALE, member);
-            Room savedRoom = roomRepository.save(room);
+            Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
+            Room room = testFixtureBuilder.buildRoom(RoomFixture.ROOM1(member));
 
             // when
             RoomResponse findRoom = roomService.findRoomById(room.getId());
 
             // then
-            assertThat(savedRoom.getId()).isEqualTo(findRoom.id());
+            assertThat(room.getId()).isEqualTo(findRoom.id());
         }
 
         @Test
         @DisplayName("모든 모임방 조회에 성공한다.")
         void successFindAllRooms() {
             // given
-            Member member = MemberFixture.MEMBER1();
-            memberRepository.save(member);
-
-            List<RoomCreateRequest> requests = RoomFixture.createRooms(member)
-                    .stream()
-                    .map(room -> new RoomCreateRequest(
-                                    room.getHeadCount(),
-                                    room.getPreferredGender().getName(),
-                                    room.getOpenChatLink(),
-                                    room.getMeetingDateTime(),
-                                    room.getTitle(),
-                                    room.getContent()
-                            )
-                    ).toList();
-            requests.forEach(request -> roomService.createRoom(request, member.getId()));
+            Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
+            List<Room> rooms = RoomFixture.createRooms(member);
+            rooms.forEach(room -> testFixtureBuilder.buildRoom(room));
 
             // when
             List<RoomResponse> findRoomResponses = roomService.findAllRooms();
 
             // then
-            assertThat(findRoomResponses).hasSize(requests.size());
+            assertThat(findRoomResponses).hasSize(rooms.size());
         }
     }
 
@@ -120,14 +97,11 @@ class RoomServiceTest extends serviceSliceTest {
         @DisplayName("수정에 성공한다.")
         void successUpdateRoomById() {
             // given
-            Member member = MemberFixture.MEMBER1();
-            memberRepository.save(member);
+            Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
+            Room room = testFixtureBuilder.buildRoom(RoomFixture.ROOM1(member));
 
-            Room room = RoomFixture.createRoom(4, Gender.MALE, member);
-            roomRepository.save(room);
-
-            int headCountToUpdate = 8;
-            Gender preferredGenderToUpdate = Gender.FEMALE;
+            int headCountToUpdate = room.getHeadCount() + 4;
+            Gender preferredGenderToUpdate = room.getPreferredGender();
 
             // when
             RoomUpdateRequest request = new RoomUpdateRequest(
@@ -155,11 +129,8 @@ class RoomServiceTest extends serviceSliceTest {
         @DisplayName("모임방을 삭제에 성공한다.")
         void deleteRoomById() {
             // given
-            Member member = MemberFixture.MEMBER1();
-            memberRepository.save(member);
-
-            Room room = RoomFixture.createRoom(4, Gender.MALE, member);
-            roomRepository.save(room);
+            Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
+            Room room = testFixtureBuilder.buildRoom(RoomFixture.ROOM1(member));
 
             // when
             roomService.deleteRoomById(room.getId(), member.getId());

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.room.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.gobongbob.festamate.common.fixture.MemberFixture;
 import com.gobongbob.festamate.common.fixture.RoomFixture;
@@ -42,15 +43,19 @@ class RoomServiceTest extends serviceSliceTest {
             // given
             Member member = testFixtureBuilder.buildMember(MemberFixture.MEMBER1());
 
-            Room room = testFixtureBuilder.buildRoom(RoomFixture.ROOM1(member));
+            Room room = RoomFixture.ROOM1(member);
             RoomCreateRequest request = RoomFixture.createRoomCreateRequest(room);
 
             // when
             Room createdRoom = roomService.createRoom(request, member.getId());
 
             // then
-            assertThat(createdRoom.getHeadCount()).isEqualTo(room.getHeadCount());
-            assertThat(createdRoom.getPreferredGender()).isEqualTo(room.getPreferredGender());
+            assertAll(
+                    () -> assertThat(createdRoom.getId()).isNotNull(),
+                    () -> assertThat(createdRoom.getHeadCount()).isEqualTo(room.getHeadCount()),
+                    () -> assertThat(createdRoom.getPreferredGender()).isEqualTo(
+                            room.getPreferredGender())
+            );
         }
     }
 
@@ -115,8 +120,10 @@ class RoomServiceTest extends serviceSliceTest {
             roomService.updateRoomById(room.getId(), member.getId(), request);
 
             // then
-            assertThat(room.getHeadCount()).isEqualTo(headCountToUpdate);
-            assertThat(room.getPreferredGender()).isEqualTo(preferredGenderToUpdate);
+            assertAll(
+                    () -> assertThat(room.getHeadCount()).isEqualTo(headCountToUpdate),
+                    () -> assertThat(room.getPreferredGender()).isEqualTo(preferredGenderToUpdate)
+            );
         }
     }
 

--- a/src/test/java/com/gobongbob/festamate/serviceSliceTest.java
+++ b/src/test/java/com/gobongbob/festamate/serviceSliceTest.java
@@ -1,5 +1,7 @@
 package com.gobongbob.festamate;
 
+import com.gobongbob.festamate.common.builder.TestFixtureBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,4 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public abstract class serviceSliceTest {
 
+    @Autowired
+    protected TestFixtureBuilder testFixtureBuilder;
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#28 

### 📝 작업 내용
- 테스트용 객체 생성 관련 중복 코드를 정적 팩토리 메서드로 분리
- 기존 테스트 로직에 assertAll 문법 적용

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
`common/fixture` 랑 `common/builder` 경로에 테스트용 객체 생성 로직을 어떻게 빼놨는지 확인해보시면 
나중에 테스트 코드 짤 때 도움이 될 것 같습니다!
