### PR TITLE
학생증 인증 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,15 +75,6 @@ jobs:
             # Docker Hub 로그인
             echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             
-            # 환경 변수 파일 생성 (민감한 정보는 GitHub Secrets에서 가져옴)
-            cat > .env << EOF
-            DB_URL=${{ secrets.DB_URL }}
-            DB_USER=${{ secrets.DB_USER }}
-            DB_PASS=${{ secrets.DB_PASS }}
-            EOF
-            
-            pwd
-            
             # 이전 컨테이너 중지 및 제거
             docker stop festamate || true
             docker rm festamate || true
@@ -93,7 +84,6 @@ jobs:
             
             # 컨테이너 시작
             docker run -d --name festamate -p 8080:8080 --env-file .env gobongbab/festamate:latest
-            
             
             # 사용하지 않는 이미지 정리
             docker image prune -af

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,9 @@ jobs:
       # 4) .build시작 >> 리눅스 명령어다.
       # 빌드와 테스트를 함께 실행
       - name: Build and Test with Gradle
+        env:
+          OCR_API_URL: ${{ secrets.OCR_API_URL }}
+          OCR_API_SECRET: ${{ secrets.OCR_API_SECRET }}
         run: ./gradlew clean build
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,8 @@ jobs:
       # 4) .build시작 >> 리눅스 명령어다.
       # 빌드와 테스트를 함께 실행
       - name: Build and Test with Gradle
+        env:
+          OCR_API_URL: ${{ secrets.OCR_API_URL }}
+          OCR_API_SECRET: ${{ secrets.OCR_API_SECRET }}
         run: ./gradlew clean build
         shell: bash

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,6 @@ services:
       - "8080:8080"
     restart: unless-stopped
     environment:
-      # 여기 DB_HOST랑 DB_NAME이랑 나눈 이유가 뭐지???? 그냥 URL 한 번에 적으면 안되나??
       - USE_PROFILE=dev
       - DB_URL=${DB_URL}
       - DB_USER=${DB_USER}

--- a/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
@@ -1,0 +1,157 @@
+package com.gobongbob.festamate.domain.image.application;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OcrService {
+
+    @Value("${naver.ocr.api.url}")
+    private String ocrApiUrl;
+
+    @Value("${naver.ocr.api.secret}")
+    private String ocrApiSecret;
+
+    private final MemberRepository memberRepository;
+
+    public Member checkStudentCard(MultipartFile file, Long memberId) throws IOException {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        // 파일이 비어있거나 null인 경우 예외 처리
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        // 임시 파일로 저장
+        Path tempFile = Files.createTempFile("tempImage", file.getOriginalFilename());
+        file.transferTo(tempFile.toFile());
+
+        // OCR API 호출
+        String result = callOcrApi(tempFile.toFile());
+
+        // JSON 파싱
+        String studentName = getValueAfterKeyword(result, "성명");
+        String studentDepartment = getValueAfterKeyword(result, "학과");
+        String studentId = getValueAfterKeyword(result, "학번");
+
+        // 임시 파일 삭제
+        Files.delete(tempFile);
+
+        member.setStudentInfo(studentName, studentDepartment, studentId);
+
+        return memberRepository.save(member);
+    }
+    private String getValueAfterKeyword(String json, String keyword) {
+        try {
+            // ObjectMapper는 JSON 데이터를 Java 객체로 변환하거나, Java 객체를 JSON으로 변환하는 기능을 제공
+            ObjectMapper mapper = new ObjectMapper();
+            // 입력된 JSON 문자열(json)을 파싱하여 트리 형태의 데이터 구조(JsonNode)로 변환합니다.
+            JsonNode rootNode = mapper.readTree(json);
+
+            /**
+             * 예시
+             * {
+             *   "name": "홍길동",
+             *   "age": 25,
+             *   "address": {
+             *     "city": "서울",
+             *     "zipcode": "12345"
+             *   }
+             * }
+             * 위 json을 트리 형태의 데이터 구조(JsonNode)로 변환하면 아래처럼 됨
+             * rootNode
+             * ├── name: "홍길동"
+             * ├── age: 25
+             * └── address
+             *     ├── city: "서울"
+             *     └── zipcode: "12345"
+             *
+             * 다음과 같이 접근 가능
+             * String name = rootNode.path("name").asText(); // 홍길동
+             * int age = rootNode.path("age").asInt(); // 25
+             * String city = rootNode.path("address").path("city").asText(); // 서울
+             *
+             * */
+
+            // "images" 배열에서 첫 번째 요소를 가져옴
+            JsonNode fields = rootNode.path("images").get(0).path("fields");
+
+            // "성명" 다음에 오는 inferText 값을 찾기 위한 반복문
+            boolean foundKeyword = false;
+            for (JsonNode field : fields) {
+                String inferText = field.path("inferText").asText();
+
+                if (foundKeyword) {
+                    // 키워드 다음의 inferText를 찾았으므로 반환
+                    return inferText;
+                }
+
+                if (keyword.equals(inferText)) {
+                    // 키워드를 찾았으므로 플래그를 true로 설정
+                    foundKeyword = true;
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // 찾지 못했을 경우 null 반환
+        return null;
+    }
+
+    private String callOcrApi(File file) {
+        // OCR API InvokeURL과 Secret Key를 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.set("X-OCR-SECRET", ocrApiSecret);
+
+        // 파일로부터 파일 이름을 가져옴
+        String filename = file.getName();
+
+        // uuid를 만들고 timestamp를 현재 시간으로 설정
+        String message = String.format(
+                "{\"version\": \"v1\", \"requestId\": \"%s\", \"timestamp\": %d, \"lang\": \"ko\", \"images\": [{\"format\": \"jpg\", \"name\": \"%s\"}]}",
+                java.util.UUID.randomUUID().toString(),
+                System.currentTimeMillis(),
+                filename
+        );
+
+        // RestTemplate을 사용하여 multipart/form-data 형식으로 파일과 메시지를 전송
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new FileSystemResource(file));
+        body.add("message", message);
+
+        // RestTemplate을 사용하여 POST 요청을 보낼 때, HttpEntity를 사용하여 헤더와 바디를 설정
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        // RestTemplate을 사용하여 POST 요청을 보냄
+        RestTemplate restTemplate = new RestTemplate();
+        String result = restTemplate.postForObject(ocrApiUrl, requestEntity, String.class);
+
+        return result;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.domain.image.application;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gobongbob.festamate.domain.image.dto.response.StudentInfoResponse;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class OcrService {
 
     private final MemberRepository memberRepository;
 
-    public Member checkStudentCard(MultipartFile file, Long memberId) throws IOException {
+    public StudentInfoResponse checkStudentCard(MultipartFile file, Long memberId) throws IOException {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
 
@@ -61,8 +62,9 @@ public class OcrService {
         Files.delete(tempFile);
 
         member.setStudentInfo(studentName, studentDepartment, studentId);
+        memberRepository.save(member);
 
-        return memberRepository.save(member);
+        return StudentInfoResponse.fromEntity(studentName, studentDepartment, studentId);
     }
     private String getValueAfterKeyword(String json, String keyword) {
         try {

--- a/src/main/java/com/gobongbob/festamate/domain/image/dto/response/StudentInfoResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/dto/response/StudentInfoResponse.java
@@ -1,0 +1,16 @@
+package com.gobongbob.festamate.domain.image.dto.response;
+
+public record StudentInfoResponse(
+        String name,
+        String studentDepartment,
+        String studentId
+) {
+
+    public static StudentInfoResponse fromEntity(String name, String studentDepartment, String studentId) {
+        return new StudentInfoResponse(
+                name,
+                studentDepartment,
+                studentId
+        );
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
@@ -1,0 +1,151 @@
+package com.gobongbob.festamate.domain.image.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping()
+public class OcrController {
+
+    private static final Logger log = LoggerFactory.getLogger(OcrController.class);
+    @Value("${naver.ocr.api.url}")
+    private String ocrApiUrl;
+
+    @Value("${naver.ocr.api.secret}")
+    private String ocrApiSecret;
+
+
+    @PostMapping("/api/check/student-card")
+    public String performOcr(@RequestParam("file") MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File cannot be empty");
+        }
+
+        // 임시 파일로 저장
+        Path tempFile = Files.createTempFile("tempImage", file.getOriginalFilename());
+        file.transferTo(tempFile.toFile());
+
+        // OCR API 호출
+        String result = callOcrApi(tempFile.toFile());
+
+
+        String studentName = getNameAfterKeyword(result, "성명");
+        String studentId = getNameAfterKeyword(result, "학번");
+
+        log.warn("studentName ->" + studentName);
+        log.warn("studentId ->" + studentId);
+        // 임시 파일 삭제
+        Files.delete(tempFile);
+
+        return result;
+    }
+
+    private String getNameAfterKeyword(String json, String keyword) {
+        try {
+            // ObjectMapper는 JSON 데이터를 Java 객체로 변환하거나, Java 객체를 JSON으로 변환하는 기능을 제공
+            ObjectMapper mapper = new ObjectMapper();
+            // 입력된 JSON 문자열(json)을 파싱하여 트리 형태의 데이터 구조(JsonNode)로 변환합니다.
+            JsonNode rootNode = mapper.readTree(json);
+
+            /**
+             * 예시
+             * {
+             *   "name": "홍길동",
+             *   "age": 25,
+             *   "address": {
+             *     "city": "서울",
+             *     "zipcode": "12345"
+             *   }
+             * }
+             * 위 json을 트리 형태의 데이터 구조(JsonNode)로 변환하면 아래처럼 됨
+             * rootNode
+             * ├── name: "홍길동"
+             * ├── age: 25
+             * └── address
+             *     ├── city: "서울"
+             *     └── zipcode: "12345"
+             *
+             * 다음과 같이 접근 가능
+             * String name = rootNode.path("name").asText(); // 홍길동
+             * int age = rootNode.path("age").asInt(); // 25
+             * String city = rootNode.path("address").path("city").asText(); // 서울
+             *
+             * */
+
+            // "images" 배열에서 첫 번째 요소를 가져옴
+            JsonNode fields = rootNode.path("images").get(0).path("fields");
+
+            // "성명" 다음에 오는 inferText 값을 찾기 위한 반복문
+            boolean foundKeyword = false;
+            for (JsonNode field : fields) {
+                String inferText = field.path("inferText").asText();
+
+                if (foundKeyword) {
+                    // 키워드 다음의 inferText를 찾았으므로 반환
+                    return inferText;
+                }
+
+                if (keyword.equals(inferText)) {
+                    // 키워드를 찾았으므로 플래그를 true로 설정
+                    foundKeyword = true;
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // 찾지 못했을 경우 null 반환
+        return null;
+    }
+
+    private String callOcrApi(File file) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.set("X-OCR-SECRET", ocrApiSecret);
+
+        // Get the filename from the file
+        String filename = file.getName();
+
+        // Create message with UUID, current timestamp and original filename
+        String message = String.format(
+                "{\"version\": \"v1\", \"requestId\": \"%s\", \"timestamp\": %d, \"lang\": \"ko\", \"images\": [{\"format\": \"jpg\", \"name\": \"%s\"}]}",
+                java.util.UUID.randomUUID().toString(),
+                System.currentTimeMillis(),
+                filename
+        );
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new FileSystemResource(file));
+        body.add("message", message);
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        String result = restTemplate.postForObject(ocrApiUrl, requestEntity, String.class);
+
+        return result;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
@@ -1,9 +1,8 @@
 package com.gobongbob.festamate.domain.image.presentation;
 
 import com.gobongbob.festamate.domain.image.application.OcrService;
-import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.image.dto.response.StudentInfoResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,10 +20,9 @@ public class OcrController {
     private final OcrService ocrService;
 
     @PostMapping("/api/check/student-card")
-    public ResponseEntity<Void> checkStudentCard(@RequestParam("file") MultipartFile file) throws IOException {
+    public ResponseEntity<StudentInfoResponse> checkStudentCard(@RequestParam("file") MultipartFile file) throws IOException {
         Long memberId = 1L; // 추후 Spring Security를 활용하여 사용자 정보를 가져오도록 변경 필요
-        Member member = ocrService.checkStudentCard(file,memberId);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ocrService.checkStudentCard(file,memberId));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
@@ -1,151 +1,30 @@
 package com.gobongbob.festamate.domain.image.presentation;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gobongbob.festamate.domain.image.application.OcrService;
+import com.gobongbob.festamate.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping()
 public class OcrController {
 
-    private static final Logger log = LoggerFactory.getLogger(OcrController.class);
-    @Value("${naver.ocr.api.url}")
-    private String ocrApiUrl;
-
-    @Value("${naver.ocr.api.secret}")
-    private String ocrApiSecret;
-
+    private final OcrService ocrService;
 
     @PostMapping("/api/check/student-card")
-    public String performOcr(@RequestParam("file") MultipartFile file) throws IOException {
-        if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("File cannot be empty");
-        }
+    public ResponseEntity<Void> checkStudentCard(@RequestParam("file") MultipartFile file) throws IOException {
+        Long memberId = 1L; // 추후 Spring Security를 활용하여 사용자 정보를 가져오도록 변경 필요
+        Member member = ocrService.checkStudentCard(file,memberId);
 
-        // 임시 파일로 저장
-        Path tempFile = Files.createTempFile("tempImage", file.getOriginalFilename());
-        file.transferTo(tempFile.toFile());
-
-        // OCR API 호출
-        String result = callOcrApi(tempFile.toFile());
-
-
-        String studentName = getNameAfterKeyword(result, "성명");
-        String studentId = getNameAfterKeyword(result, "학번");
-
-        log.warn("studentName ->" + studentName);
-        log.warn("studentId ->" + studentId);
-        // 임시 파일 삭제
-        Files.delete(tempFile);
-
-        return result;
-    }
-
-    private String getNameAfterKeyword(String json, String keyword) {
-        try {
-            // ObjectMapper는 JSON 데이터를 Java 객체로 변환하거나, Java 객체를 JSON으로 변환하는 기능을 제공
-            ObjectMapper mapper = new ObjectMapper();
-            // 입력된 JSON 문자열(json)을 파싱하여 트리 형태의 데이터 구조(JsonNode)로 변환합니다.
-            JsonNode rootNode = mapper.readTree(json);
-
-            /**
-             * 예시
-             * {
-             *   "name": "홍길동",
-             *   "age": 25,
-             *   "address": {
-             *     "city": "서울",
-             *     "zipcode": "12345"
-             *   }
-             * }
-             * 위 json을 트리 형태의 데이터 구조(JsonNode)로 변환하면 아래처럼 됨
-             * rootNode
-             * ├── name: "홍길동"
-             * ├── age: 25
-             * └── address
-             *     ├── city: "서울"
-             *     └── zipcode: "12345"
-             *
-             * 다음과 같이 접근 가능
-             * String name = rootNode.path("name").asText(); // 홍길동
-             * int age = rootNode.path("age").asInt(); // 25
-             * String city = rootNode.path("address").path("city").asText(); // 서울
-             *
-             * */
-
-            // "images" 배열에서 첫 번째 요소를 가져옴
-            JsonNode fields = rootNode.path("images").get(0).path("fields");
-
-            // "성명" 다음에 오는 inferText 값을 찾기 위한 반복문
-            boolean foundKeyword = false;
-            for (JsonNode field : fields) {
-                String inferText = field.path("inferText").asText();
-
-                if (foundKeyword) {
-                    // 키워드 다음의 inferText를 찾았으므로 반환
-                    return inferText;
-                }
-
-                if (keyword.equals(inferText)) {
-                    // 키워드를 찾았으므로 플래그를 true로 설정
-                    foundKeyword = true;
-                }
-            }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        // 찾지 못했을 경우 null 반환
-        return null;
-    }
-
-    private String callOcrApi(File file) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        headers.set("X-OCR-SECRET", ocrApiSecret);
-
-        // Get the filename from the file
-        String filename = file.getName();
-
-        // Create message with UUID, current timestamp and original filename
-        String message = String.format(
-                "{\"version\": \"v1\", \"requestId\": \"%s\", \"timestamp\": %d, \"lang\": \"ko\", \"images\": [{\"format\": \"jpg\", \"name\": \"%s\"}]}",
-                java.util.UUID.randomUUID().toString(),
-                System.currentTimeMillis(),
-                filename
-        );
-
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-        body.add("file", new FileSystemResource(file));
-        body.add("message", message);
-
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-        String result = restTemplate.postForObject(ocrApiUrl, requestEntity, String.class);
-
-        return result;
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -1,18 +1,8 @@
 package com.gobongbob.festamate.domain.member.domain;
 
 import com.gobongbob.festamate.domain.major.domain.Major;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
@@ -47,8 +37,16 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Major major;
 
+    private String studentDepartment; // 임시 필드, 학생증 등록으로 학과 정보 기입을 할 예정이면 이 필드를 사용. 추후 의논해야 함.
+
     public void updateProfile(String nickname, String loginPassword) {
         this.nickname = nickname;
         this.loginPassword = loginPassword;
+    }
+
+    public void setStudentInfo( String studentName, String studentDepartment, String studentId) {
+        this.name = studentName;
+        this.studentDepartment = studentDepartment;
+        this.studentId = studentId;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,8 @@ spring:
         hbm2ddl:
           auto: create
         default_batch_fetch_size: 1000
+naver:
+  ocr:
+    api:
+      url: ${OCR_API_URL}
+      secret: ${OCR_API_SECRET}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,8 @@ spring:
 
 logging.level:
   org.hibernate.SQL: debug
+naver:
+  ocr:
+    api:
+      url: ${OCR_API_URL}
+      secret: ${OCR_API_SECRET}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#32 

### 📝 작업 내용
1. 네이버 OCR API를 통해 학생증 사진의 이름, 학과, 학번 정보를 가져옵니다.
2. 추후 학생증 속 날짜와 현재 날짜가 일치한 지 검증을 추가할 수도 있을 것 같습니다.
3. 일단 memberId가 1인 유저가 학생증 인증한다는 가정으로 구현했습니다. 추후 JWT 토큰으로 유저 정보를 가져오는 로직을 추가해야 합니다.

### 📷 스크린샷 (선택)
- API 요청 전
![image](https://github.com/user-attachments/assets/bee17d17-c4d9-47eb-af6c-8a7c9cfebfef)

- API 요청
로컬용
![image](https://github.com/user-attachments/assets/0228b890-aad2-4f92-9c02-9d898dfffb22)

- API 요청 후
![image](https://github.com/user-attachments/assets/ca446b5e-c1fb-4366-bbe5-089cbc5b195d)


### 💬 리뷰 요구사항 (선택)
1. 처음 유저가 서비스에 접속했을 경우 서비스를 둘러볼 수 있게 한 뒤 서비스를 이용하고자 할 때 회원가입을 시키면 좋을 것 같습니다. 
이때 학생증을 통해 알 수 있는 정보들(성명,학과,학번)은 따로 기입할 필요 없이 OCR 기술을 통해 저장하면 편하겠다고 느꼈습니다.  

2. 이름, 학과, 학번이 매우 이상(?)할 때의 예외 처리가 필요할까요? (사진을 조작할 유저가 있을지....)