### PR TITLE
프로필 등록 기능 구현

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.member.application;
 
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.dto.request.MemberCreateRequest;
+import com.gobongbob.festamate.domain.member.dto.request.ProfileRegisterRequest;
 import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
@@ -58,6 +59,16 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
 
         memberRepository.delete(member);
+    }
+
+    // 프로필 등록 API
+    @Transactional
+    public void registerProfile(ProfileRegisterRequest request, Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
+
+        Member registeredMember = request.toEntity(member); // 기존 Member 정보 그대로 사용
+        memberRepository.save(registeredMember);
     }
 
     // 아래부터는 oauth2를 위한 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -43,9 +43,9 @@ public class Member {
     private String studentId;
 
     @Column(unique = true)
-    private String loginId;
+    private String loginId; // 관리자 일반 로그인 관련 필드
 
-    private String loginPassword;
+    private String loginPassword; // 관리자 일반 로그인 관련 필드
 
     @Column(unique = true)
     private String phoneNumber;

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileRegisterRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileRegisterRequest.java
@@ -1,0 +1,28 @@
+package com.gobongbob.festamate.domain.member.dto.request;
+
+import com.gobongbob.festamate.domain.major.domain.Major;
+import com.gobongbob.festamate.domain.member.domain.Gender;
+import com.gobongbob.festamate.domain.member.domain.Member;
+
+// 프로필 등록용 DTO
+public record ProfileRegisterRequest(
+        String name,
+        String nickname,
+        String studentId,
+        String phoneNumber,
+        String gender,
+        String college,
+        String department
+) {
+
+    // Member 엔티티로 변환하는 메서드
+    public Member toEntity(Member existingMember) {
+        existingMember.setName(name);
+        existingMember.setNickname(nickname);
+        existingMember.setStudentId(studentId);
+        existingMember.setPhoneNumber(phoneNumber);
+        existingMember.setGender(Gender.findByName(gender));
+        existingMember.setMajor(Major.findByDepartment(department));
+        return existingMember;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.domain.member.presentation;
 import com.gobongbob.festamate.domain.member.application.MemberService;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.dto.request.MemberCreateRequest;
+import com.gobongbob.festamate.domain.member.dto.request.ProfileRegisterRequest;
 import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
@@ -61,6 +62,15 @@ public class MemberController {
     public ResponseEntity<Void> deleteMemberById(@PathVariable Long memberId) {
         memberService.deleteMemberById(memberId);
 
+        return ResponseEntity.ok().build();
+    }
+
+    // 프로필 등록 API
+    @PostMapping("/api/auth/register/profile") // 추후 /api/auth를 상위 경로에 작성하도록 변경 필요
+    public ResponseEntity<Void> registerProfile(@RequestBody ProfileRegisterRequest request,
+            @AuthenticationPrincipal Member member) {
+        Long userId = member.getId();
+        memberService.registerProfile(request, userId);
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#63 

### 📝 작업 내용
- 카카오 소셜 로그인을 구현한 뒤에 회원가입을 마저 진행합니다.
- 닉네임, 성별, 이름, 학번, 학부, 학과, 전화번호를 입력받습니다.
- `@AuthenticationPrincipal Member member` 를 통한 사용자 정보 접근이 가능합니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7124f042-5dba-4053-8994-2fa74f76f985)


### 💬 리뷰 요구사항 (선택)
1. #65 에서 스프링 시큐리티 경로를 확정하겠습니다. 
2. 아직 테스트 코드가 잘 동작하지 않아서 별도의 테스트 코드는 없으며, 포스트맨을 이용한 테스트만 가능합니다. 
3. 저희가 만든 회원가입 뷰에서는 닉네임과 성별을 먼저 입력받고, 그 다음 페이지에서 나머지 정보를 받도록 되어있습니다. 이 경우 지금처럼 하나의 DTO에 모든 요청을 담아도 되는 건지 궁금합니다.
4. 스크린샷을 보시면 전공 정보만 저장되도록 구현되어 있으며 별도의 단과대 정보는 저장하지 않습니다. 이전에 작성해주신 Major enum을 보면 findByDepartment() 를 통해 major만 반환하도록 되어있습니다. 의도하신 부분이 맞는지 확인 부탁드립니다!
