### PR TITLE
닉네임 중복 체크 기능 구현

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -64,7 +64,7 @@ public class MemberService {
     // 프로필 등록 API
     @Transactional
     public void registerProfile(ProfileRegisterRequest request, Long userId) {
-        checkNicknameDuplication(request.getNickname()); // 프로필 등록 중 닉네임 중복 확인 필요함
+        checkNicknameDuplication(request.nickname()); // 프로필 등록 중 닉네임 중복 확인 필요함
 
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));

--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -64,11 +64,23 @@ public class MemberService {
     // 프로필 등록 API
     @Transactional
     public void registerProfile(ProfileRegisterRequest request, Long userId) {
+        checkNicknameDuplication(request.getNickname()); // 프로필 등록 중 닉네임 중복 확인 필요함
+
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
 
         Member registeredMember = request.toEntity(member); // 기존 Member 정보 그대로 사용
         memberRepository.save(registeredMember);
+    }
+
+    // 닉네임 중복 체크
+    @Transactional
+    public void checkNicknameDuplication(String nickname) {
+        boolean isDuplicate = memberRepository.existsByNickname(nickname);
+
+        if (isDuplicate) {
+            throw new IllegalArgumentException("중복된 닉네임입니다.");
+        }
     }
 
     // 아래부터는 oauth2를 위한 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/member/persistence/MemberRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/persistence/MemberRepository.java
@@ -17,4 +17,6 @@ public interface MemberRepository extends Repository<Member, Long> {
     void delete(Member room);
 
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+
+    boolean existsByNickname(String nickname); // 닉네임 중복 확인
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -71,6 +72,13 @@ public class MemberController {
             @AuthenticationPrincipal Member member) {
         Long userId = member.getId();
         memberService.registerProfile(request, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 닉네임 중복 확인 API
+    @GetMapping("/api/auth/register/check/nickname")
+    public ResponseEntity<String> checkNickname(@RequestParam String nickname) {
+        memberService.checkNicknameDuplication(nickname);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
@@ -25,10 +25,10 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         /** 테스트를 위해 임시 비활성화
          String requestUri = request.getRequestURI();
 
-         // 로그인, 카카오 및 리프레시 엔드포인트는 필터를 건너뜀
+         // 로그인, 카카오 및 리프레시, 닉네임 중복 확인 엔드포인트는 필터를 건너뜀
          if ("/api/auth/login".equals(requestUri) || "/api/auth/refresh".equals(requestUri)
-         || "/login/oauth2/code/kakao".equals(
-         requestUri)) {
+         || "/login/oauth2/code/kakao".equals(requestUri)
+         || "/api/auth/register/check/nickname".equals(requestUri)) {
          filterChain.doFilter(request, response);
          return;
          }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#72 

### 📝 작업 내용
JPA를 사용하여 회원가입 중 닉네임 중복 체크를 할 수 있도록 구현합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
일관된 예외처리가 필요할 것 같습니다.

인증 필터도 빨리 수정해야 할 것 같네요. 테스트가 번거로워요😂😂😂😂😂😂
