### PR TITLE
경로 인증 활성화 및 테스트 유저 생성

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/TokenService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/TokenService.java
@@ -3,6 +3,8 @@ package com.gobongbob.festamate.domain.auth.jwt.application;
 import com.gobongbob.festamate.domain.member.application.MemberService;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.global.util.TokenProvider;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,18 +16,74 @@ public class TokenService {
     private final RefreshJwtTokenService refreshJwtTokenService;
     private final MemberService memberService;
 
-    public String createNewAccessToken(String refreshToken) {
-        // Refresh Token 유효성 및 타입 확인
-        if (!tokenProvider.validateToken(refreshToken) || !tokenProvider.isRefreshToken(
-                refreshToken)) {
-            throw new IllegalArgumentException("Invalid or unexpected token");
-        }
 
-        // Refresh Token으로 회원 ID 조회
-        Long memberId = refreshJwtTokenService.findByRefreshToken(refreshToken).getMemberId();
+    // 새로운 초기 Access Token 생성 메서드
+    public String createNewInitialAccessToken(String refreshToken) {
+        validateInitialRefreshToken(refreshToken);
+        Long memberId = getMemberIdFromRefreshToken(refreshToken);
         Member member = memberService.findById(memberId);
+        return tokenProvider.generateInitialAccessToken(member);
+    }
 
-        // 새로운 Access Token 생성
-        return tokenProvider.generateAccessToken(member);
+    // 새로운 최종 Access Token 생성 메서드
+    public String createNewFinalAccessToken(String refreshToken) {
+        validateFinalRefreshToken(refreshToken);
+        Long memberId = getMemberIdFromRefreshToken(refreshToken);
+        Member member = memberService.findById(memberId);
+        return tokenProvider.generateFinalAccessToken(member);
+    }
+
+    // 새로운 테스트용 Access Token 생성 메서드
+    public String createNewTestAccessToken(String refreshToken) {
+        validateTestRefreshToken(refreshToken);
+        Long memberId = getMemberIdFromRefreshToken(refreshToken);
+        Member member = memberService.findById(memberId);
+        return tokenProvider.generateTestAccessToken(member);
+    }
+
+    // 초기 Refresh Token 유효성 및 타입 확인 메서드
+    private void validateInitialRefreshToken(String refreshToken) {
+        if (!tokenProvider.validateToken(refreshToken) || !tokenProvider.isInitialRefreshToken(
+                refreshToken)) {
+            throw new IllegalArgumentException("Invalid or unexpected initial refresh token");
+        }
+    }
+
+    // 최종 Refresh Token 유효성 및 타입 확인 메서드
+    private void validateFinalRefreshToken(String refreshToken) {
+        if (!tokenProvider.validateToken(refreshToken) || !tokenProvider.isFinalRefreshToken(
+                refreshToken)) {
+            throw new IllegalArgumentException("Invalid or unexpected final refresh token");
+        }
+    }
+
+    // 테스트용 Refresh Token 유효성 및 타입 확인 메서드
+    private void validateTestRefreshToken(String refreshToken) {
+        if (!tokenProvider.validateToken(refreshToken) || !tokenProvider.isTestRefreshToken(
+                refreshToken)) {
+            throw new IllegalArgumentException("Invalid or unexpected test refresh token");
+        }
+    }
+
+    // Refresh Token으로 회원 ID 조회 메서드
+    private Long getMemberIdFromRefreshToken(String refreshToken) {
+        return refreshJwtTokenService.findByRefreshToken(refreshToken).getMemberId();
+    }
+
+    // 최종 JWT(access, refresh) 생성 메서드
+    public Map<String, String> generateTokens(Long userId) {
+        // userId로 Member 객체를 가져오기
+        Member member = memberService.findMembersById(userId); // Member 객체로 반환
+
+        // Member 객체를 사용하여 Access Token과 Refresh Token 생성
+        String accessToken = tokenProvider.generateFinalAccessToken(member);  // Member 사용
+        String refreshToken = tokenProvider.generateFinalRefreshToken(member); // Member 사용
+
+        // JWT 토큰들을 Map으로 반환
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+
+        return tokens;
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/MinimalMemberDetails.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/MinimalMemberDetails.java
@@ -1,0 +1,55 @@
+package com.gobongbob.festamate.domain.auth.jwt.domain;
+
+import com.gobongbob.festamate.domain.member.domain.Member;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class MinimalMemberDetails implements UserDetails {
+
+    private final Long id;
+
+    public MinimalMemberDetails(Member member) {
+        this.id = member.getId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -21,10 +21,28 @@ public class TokenController {
     private final TokenService tokenService;
     private final TokenProvider tokenProvider;
 
-    @PostMapping("/refresh") // refresh jwt로 access jwt 받아옴
+    @PostMapping("/refresh") // 초기 refresh jwt로 access jwt 받아옴
     public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(
             @RequestBody CreateAccessTokenRequest request) {
-        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        String newAccessToken = tokenService.createNewInitialAccessToken(request.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+
+    @PostMapping("/refresh/final") // 최종 refresh jwt로 access jwt 받아옴
+    public ResponseEntity<CreateAccessTokenResponse> createNewFinalAccessToken(
+            @RequestBody CreateAccessTokenRequest request) {
+        String newAccessToken = tokenService.createNewFinalAccessToken(request.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+
+    @PostMapping("/refresh/test") // 테스트용 refresh jwt로 access jwt 받아옴
+    public ResponseEntity<CreateAccessTokenResponse> createNewTestAccessToken(
+            @RequestBody CreateAccessTokenRequest request) {
+        String newAccessToken = tokenService.createNewTestAccessToken(request.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CreateAccessTokenResponse(newAccessToken));

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/application/OauthService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/application/OauthService.java
@@ -73,8 +73,8 @@ public class OauthService {
             // 3. 사용자 정보 저장 또는 업데이트
             Member member = registerKakaoUser(userInfo, oauthAccessToken);
 
-            // 4. JWT 생성 및 저장
-            Map<String, String> tokens = generateJwtTokens(member, request, response);
+            // 4. 초기 JWT 생성 및 저장
+            Map<String, String> tokens = generateInitialJwtTokens(member, request, response);
 
             return tokens;
 
@@ -83,14 +83,50 @@ public class OauthService {
         }
     }
 
-    private Map<String, String> generateJwtTokens(Member member, HttpServletRequest request,
+    private Map<String, String> generateInitialJwtTokens(Member member, HttpServletRequest request,
             HttpServletResponse response) {
-        // JWT 액세스 토큰 생성
-        String accessToken = tokenProvider.generateAccessToken(member);
+        // 초기 JWT 액세스 토큰 생성
+        String accessToken = tokenProvider.generateInitialAccessToken(member);
         response.setHeader(ACCESS_HEADER, accessToken);
 
-        // JWT 리프레시 토큰 생성 및 저장
-        String refreshToken = tokenProvider.generateRefreshToken(member);
+        // 초기 JWT 리프레시 토큰 생성 및 저장
+        String refreshToken = tokenProvider.generateInitialRefreshToken(member);
+        saveRefreshToken(member.getId(), refreshToken);
+        addRefreshTokenToCookie(request, response, refreshToken);
+
+        // 응답 데이터 구성
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("access_token", accessToken);
+        tokens.put("refresh_token", refreshToken);
+        return tokens;
+    }
+
+    private Map<String, String> generateFinalJwtTokens(Member member, HttpServletRequest request,
+            HttpServletResponse response) {
+        // 최종 JWT 액세스 토큰 생성
+        String accessToken = tokenProvider.generateFinalAccessToken(member);
+        response.setHeader(ACCESS_HEADER, accessToken);
+
+        // 최종 JWT 리프레시 토큰 생성 및 저장
+        String refreshToken = tokenProvider.generateFinalRefreshToken(member);
+        saveRefreshToken(member.getId(), refreshToken);
+        addRefreshTokenToCookie(request, response, refreshToken);
+
+        // 응답 데이터 구성
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("access_token", accessToken);
+        tokens.put("refresh_token", refreshToken);
+        return tokens;
+    }
+
+    private Map<String, String> generateTestJwtTokens(Member member, HttpServletRequest request,
+            HttpServletResponse response) {
+        // 테스트용 JWT 액세스 토큰 생성
+        String accessToken = tokenProvider.generateTestAccessToken(member);
+        response.setHeader(ACCESS_HEADER, accessToken);
+
+        // 테스트용 JWT 리프레시 토큰 생성 및 저장
+        String refreshToken = tokenProvider.generateTestRefreshToken(member);
         saveRefreshToken(member.getId(), refreshToken);
         addRefreshTokenToCookie(request, response, refreshToken);
 

--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -39,6 +39,11 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
     }
 
+    public Member findMembersById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+    }
+
     public MemberProfileResponse findProfile(Member member) {
         return MemberProfileResponse.fromEntity(member);
     }

--- a/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
@@ -1,6 +1,8 @@
 package com.gobongbob.festamate.domain.member.presentation;
 
+import com.gobongbob.festamate.domain.auth.jwt.application.TokenService;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
+import com.gobongbob.festamate.domain.auth.jwt.domain.MinimalMemberDetails;
 import com.gobongbob.festamate.domain.member.application.MemberService;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.dto.request.MemberCreateRequest;
@@ -9,6 +11,7 @@ import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TokenService tokenService;
 
     @PostMapping("/auth/signup")
     public ResponseEntity<Void> signUp(@RequestBody MemberCreateRequest request) {
@@ -44,7 +48,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.findMemberById(memberId));
     }
 
-    @GetMapping("/api/auth/members/profile")
+    @GetMapping("/api/members/profile")
     public ResponseEntity<MemberProfileResponse> getProfile(
             @AuthenticationPrincipal CustomMemberDetails memberDetails) {
         return ResponseEntity.ok(memberService.findProfile(memberDetails.getMember()));
@@ -69,11 +73,18 @@ public class MemberController {
 
     // 프로필 등록 API
     @PostMapping("/api/auth/register/profile") // 추후 /api/auth를 상위 경로에 작성하도록 변경 필요
-    public ResponseEntity<Void> registerProfile(@RequestBody ProfileRegisterRequest request,
-            @AuthenticationPrincipal Member member) {
-        Long userId = member.getId();
+    public ResponseEntity<Map<String, String>> registerProfile(
+            @RequestBody ProfileRegisterRequest request,
+            @AuthenticationPrincipal MinimalMemberDetails memberDetails) { // 최소 JWT 정보
+
+        Long userId = memberDetails.getId();
         memberService.registerProfile(request, userId);
-        return ResponseEntity.ok().build();
+
+        // TokenService를 이용하여 최종 JWT(access, refresh) 생성
+        Map<String, String> tokens = tokenService.generateTokens(userId);
+
+        // 최종 JWT 반환
+        return ResponseEntity.ok(tokens);
     }
 
     // 닉네임 중복 확인 API

--- a/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
@@ -39,11 +39,10 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(
                                 SessionCreationPolicy.STATELESS)) // 세션을 생성하지 않고, 토큰 기반 인증을 사용
                 .authorizeHttpRequests(authorize -> authorize // 요청에 대한 인증 및 인가 설정 시작
-                                /*** 테스트를 위해 임시 비활성화
-                                 //                        .requestMatchers("/api/auth/**", "/login/oauth2/code/kakao", "/health")
-                                 //                        .permitAll() // 경로에 대한 요청은 인증 없이 접근 가능 */
-                                .anyRequest().permitAll() // 모든 요청 허용
-                        /**.anyRequest().authenticated() // 나머지 요청은 인증이 필요*/
+                        .requestMatchers("/api/auth/**", "/login/oauth2/code/kakao", "/health")
+                        .permitAll() // 인증 없이 접근 가능한 경로 설정
+                        .requestMatchers("/test/**").permitAll() // 테스트용 경로 허용
+                        .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .cors(withDefaults())
                 .addFilterBefore(new TokenAuthenticationFilter(tokenProvider),
@@ -54,10 +53,5 @@ public class SecurityConfig {
                                 new JwtAuthenticationEntryPoint()) // 인증 실패 시 예외 처리
                         .accessDeniedHandler(new JwtAccessDeniedHandler())); // 인가 실패 시 예외 처리
         return http.build();
-    }
-
-    @Bean
-    public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(tokenProvider);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
@@ -1,11 +1,15 @@
 package com.gobongbob.festamate.global.util;
 
+import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
+import com.gobongbob.festamate.domain.auth.jwt.domain.MinimalMemberDetails;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 // JWT를 검증하고 인증 정보를 설정하는 클래스
@@ -22,39 +26,47 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
 
-        /** 테스트를 위해 임시 비활성화
-         String requestUri = request.getRequestURI();
+        String requestUri = request.getRequestURI();
 
-         // 로그인, 카카오 및 리프레시, 닉네임 중복 확인 엔드포인트는 필터를 건너뜀
-         if ("/api/auth/login".equals(requestUri) || "/api/auth/refresh".equals(requestUri)
-         || "/login/oauth2/code/kakao".equals(requestUri)
-         || "/api/auth/register/check/nickname".equals(requestUri)) {
-         filterChain.doFilter(request, response);
-         return;
-         }
+        if (requestUri.startsWith("/test/")
+                || "/login/oauth2/code/kakao".equals(requestUri)
+                || requestUri.startsWith("/api/auth/") && !"/api/auth/register/profile".equals(
+                requestUri)
+                || "/health".equals(requestUri)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-         // 요청 헤더의 Authorization 키의 값 조회
-         String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-         // 가져온 값에서 접두사 제거
-         String token = getAccessToken(authorizationHeader);
-         // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
-         if (token != null && tokenProvider.validateToken(token) && tokenProvider.isAccessToken(
-         token)) {
-         Authentication authentication = tokenProvider.getAuthentication(token);
-         SecurityContextHolder.getContext().setAuthentication(authentication);
-         } else {
-         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 처리
-         return;
-         }*/
+        // 요청 헤더의 Authorization 키의 값 조회
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        // 가져온 값에서 접두사 제거
+        String token = getAccessToken(authorizationHeader);
+        // 가져온 토큰이 유효한지 확인하고, 유효한 때는 인증 정보 설정
+        if (token != null && tokenProvider.validateToken(token) &&
+                (tokenProvider.isInitialAccessToken(token) || tokenProvider.isFinalAccessToken(
+                        token) || tokenProvider.isTestAccessToken(
+                        token))) { // 테스트용 Access Token도 검증
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof MinimalMemberDetails
+                    || principal instanceof CustomMemberDetails) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 처리
+                return;
+            }
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 인증 실패 처리
+            return;
+        }
 
         filterChain.doFilter(request, response);
     }
 
-    /** 테스트를 위해 임시 비활성화
-     private String getAccessToken(String authorizationHeader) {
-     if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
-     return authorizationHeader.substring(TOKEN_PREFIX.length());
-     }
-     return null;
-     }*/
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
@@ -1,19 +1,21 @@
 package com.gobongbob.festamate.global.util;
 
+import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
+import com.gobongbob.festamate.domain.auth.jwt.domain.MinimalMemberDetails;
+import com.gobongbob.festamate.domain.major.domain.Major;
+import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Date;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 // 카카오 서버로부터 받은 액세스 토큰을 사용하여 자체 JWT 토큰을 생성함
@@ -26,16 +28,46 @@ public class TokenProvider {
     @Value("${JWT_SECRET}")
     private String secret;
 
-    // Access Token 생성 메서드
-    public String generateAccessToken(Member member) {
-        return makeToken(new Date(System.currentTimeMillis() + Duration.ofHours(2).toMillis()),
-                member, "access");
+    // 초기 Access Token 생성 메서드 (카카오 로그인 직후)
+    public String generateInitialAccessToken(Member member) {
+        return makeInitialUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofHours(2).toMillis()), member,
+                "initial_access");
     }
 
-    // Refresh Token 생성 메서드
-    public String generateRefreshToken(Member member) {
-        return makeToken(new Date(System.currentTimeMillis() + Duration.ofDays(7).toMillis()),
-                member, "refresh");
+    // 초기 Refresh Token 생성 메서드
+    public String generateInitialRefreshToken(Member member) {
+        return makeInitialUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofDays(7).toMillis()),
+                member, "initial_refresh");
+    }
+
+    // 최종 Access Token 생성 메서드 (사용자 등록 완료 후)
+    public String generateFinalAccessToken(Member member) {
+        return makeFinalUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofHours(2).toMillis()), member,
+                "final_access");
+    }
+
+    // 최종 Refresh Token 생성 메서드
+    public String generateFinalRefreshToken(Member member) {
+        return makeFinalUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofDays(7).toMillis()),
+                member, "final_refresh");
+    }
+
+    // 테스트용 Access Token 생성 메서드
+    public String generateTestAccessToken(Member member) {
+        return makeTestUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofDays(100).toMillis()),
+                member, "test_access");
+    }
+
+    // 테스트용 Refresh Token 생성 메서드
+    public String generateTestRefreshToken(Member member) {
+        return makeTestUserToken(
+                new Date(System.currentTimeMillis() + Duration.ofDays(100).toMillis()),
+                member, "test_refresh");
     }
 
     // JWT 토큰을 실제로 생성하는 내부 메서드로, 토큰의 헤더, 페이로드, 서명을 설정함
@@ -48,7 +80,9 @@ public class TokenProvider {
      * 클레임 id : 회원 ID
      * 서명 : 비밀값과 함께 해시값을 HS256 방식으로 암호화
      */
-    private String makeToken(Date expiry, Member member, String type) {
+
+    // 초기 유저용 토큰 생성 메서드
+    private String makeInitialUserToken(Date expiry, Member member, String type) {
         Date now = new Date();
 
         return Jwts.builder()
@@ -57,7 +91,49 @@ public class TokenProvider {
                 .setExpiration(expiry)
                 .setSubject(String.valueOf(member.getId()))
                 .claim("id", member.getId())
-                .claim("type", type) // 타입 추가
+                .claim("type", type)
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+    }
+
+    // 최종 유저용 토큰 생성 메서드
+    private String makeFinalUserToken(Date expiry, Member member, String type) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .setSubject(String.valueOf(member.getId()))
+                .claim("id", member.getId())
+                .claim("name", member.getName())
+                .claim("nickname", member.getNickname())
+                .claim("studentId", member.getStudentId())
+                .claim("phoneNumber", member.getPhoneNumber())
+                .claim("gender", member.getGender().name())
+                .claim("major", member.getMajor().name())
+                .claim("type", type)
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+    }
+
+    // 테스트 유저용 토큰 생성 메서드
+    private String makeTestUserToken(Date expiry, Member member, String type) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .setSubject(String.valueOf(member.getId()))
+                .claim("id", member.getId())
+                .claim("name", member.getName()) // 추가
+                .claim("nickname", member.getNickname()) // 추가
+                .claim("studentId", member.getStudentId()) // 추가
+                .claim("phoneNumber", member.getPhoneNumber()) // 추가
+                .claim("gender", member.getGender().name()) // 추가
+                .claim("major", member.getMajor().name()) // 추가
+                .claim("type", type)
                 .signWith(SignatureAlgorithm.HS256, secret)
                 .compact();
     }
@@ -76,13 +152,79 @@ public class TokenProvider {
 
     // 토큰 기반으로 인증 정보를 가져오는 메서드
     // JWT 토큰에서 사용자 정보를 추출하여 Authentication 객체를 생성하며, 이를 통해 @AuthenticationPrincipal을 사용할 수 있음
+    // claims에서 필요한 정보를 추출하여 CustomMemberDetails 객체를 생성
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
-        Set<SimpleGrantedAuthority> authorities = Collections.singleton(
-                new SimpleGrantedAuthority("ROLE_USER"));
+        UserDetails userDetails;
 
-        return new UsernamePasswordAuthenticationToken(
-                new Member(claims.getSubject(), "", authorities), token, authorities);
+        if (isInitialAccessToken(token)) {
+            MinimalMemberDetails minimalMemberDetails = minimalMemberDetails(claims);
+            if (minimalMemberDetails == null) {
+                throw new IllegalArgumentException("Invalid token: MinimalMemberDetails is null");
+            }
+            userDetails = minimalMemberDetails;
+        } else {
+            userDetails = getCustomMemberDetailsFromClaims(claims);
+        }
+
+        if (userDetails == null) {
+            throw new IllegalArgumentException("Invalid token: UserDetails is null");
+        }
+
+        return new UsernamePasswordAuthenticationToken(userDetails, token,
+                userDetails.getAuthorities());
+    }
+
+
+    // 클레임에서 MinimalMemberDetails 객체를 생성하는 메서드(초기 정보 처리)
+    private MinimalMemberDetails minimalMemberDetails(Claims claims) {
+        Long id = claims.get("id", Long.class);
+        if (id == null) {
+            return null;
+        }
+
+        Member.MemberBuilder memberBuilder = Member.builder().id(id);
+        Member member = memberBuilder.build();
+        return new MinimalMemberDetails(member);
+    }
+
+    // 최종 정보 처리
+    private CustomMemberDetails getCustomMemberDetailsFromClaims(Claims claims) {
+        Long id = claims.get("id", Long.class);
+        if (id == null) {
+            return null;
+        }
+
+        Member.MemberBuilder memberBuilder = Member.builder().id(id);
+
+        String name = claims.get("name", String.class);
+        String nickname = claims.get("nickname", String.class);
+        String studentId = claims.get("studentId", String.class);
+        String phoneNumber = claims.get("phoneNumber", String.class);
+        String gender = claims.get("gender", String.class);
+        String major = claims.get("major", String.class);
+
+        if (name != null) {
+            memberBuilder.name(name);
+        }
+        if (nickname != null) {
+            memberBuilder.nickname(nickname);
+        }
+        if (studentId != null) {
+            memberBuilder.studentId(studentId);
+        }
+        if (phoneNumber != null) {
+            memberBuilder.phoneNumber(phoneNumber);
+        }
+        if (gender != null) {
+            memberBuilder.gender(Gender.valueOf(gender));
+        }
+        if (major != null) {
+            memberBuilder.major(Major.valueOf(major));
+        }
+
+        Member member = memberBuilder.build();
+        return new CustomMemberDetails(member);
     }
 
     // 토큰에서 회원 ID를 추출함
@@ -99,15 +241,39 @@ public class TokenProvider {
                 .getBody();
     }
 
-    // 클레임에서 토큰 타입을 확인하여 access token인지 검증하는 로직 추가
-    public boolean isAccessToken(String token) {
+    // 초기 Access Token인지 확인하는 메서드
+    public boolean isInitialAccessToken(String token) {
         Claims claims = getClaims(token);
-        return "access".equals(claims.get("type")); // 타입 검증
+        return "initial_access".equals(claims.get("type"));
     }
 
-    // Refresh Token인지 확인하는 메서드
-    public boolean isRefreshToken(String token) {
+    // 초기 Refresh Token인지 확인하는 메서드
+    public boolean isInitialRefreshToken(String token) {
         Claims claims = getClaims(token);
-        return "refresh".equals(claims.get("type")); // 타입 검증
+        return "initial_refresh".equals(claims.get("type"));
+    }
+
+    // 최종 Access Token인지 확인하는 메서드
+    public boolean isFinalAccessToken(String token) {
+        Claims claims = getClaims(token);
+        return "final_access".equals(claims.get("type"));
+    }
+
+    // 최종 Refresh Token인지 확인하는 메서드
+    public boolean isFinalRefreshToken(String token) {
+        Claims claims = getClaims(token);
+        return "final_refresh".equals(claims.get("type"));
+    }
+
+    // 테스트 Access Token인지 확인하는 메서드
+    public boolean isTestAccessToken(String token) {
+        Claims claims = getClaims(token);
+        return "test_access".equals(claims.get("type"));
+    }
+
+    // 테스트 Refresh Token인지 확인하는 메서드
+    public boolean isTestRefreshToken(String token) {
+        Claims claims = getClaims(token);
+        return "test_refresh".equals(claims.get("type"));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/testUser/TestController.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestController.java
@@ -1,0 +1,22 @@
+package com.gobongbob.festamate.testUser;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestService testService;
+
+    @PostMapping("/create")
+    public ResponseEntity<TestService.TestTokens> createTestMember() {
+        // 테스트용 유저 생성 및 JWT 토큰 반환
+        TestService.TestTokens testTokens = testService.createTestMember();
+        return ResponseEntity.ok(testTokens);
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/testUser/TestService.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestService.java
@@ -1,0 +1,61 @@
+package com.gobongbob.festamate.testUser;
+
+import com.gobongbob.festamate.domain.major.domain.Major;
+import com.gobongbob.festamate.domain.member.domain.Gender;
+import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.global.util.TokenProvider;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestService {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public TestTokens createTestMember() {
+        // 테스트용 Member 객체 생성
+        Member testMember = Member.builder()
+                .name("Test User")
+                .nickname("test_nickname")
+                .studentId("test_student_id")
+                .loginId("test_login_id")
+                .loginPassword("test_password")
+                .phoneNumber("010-0000-0000")
+                .gender(Gender.MALE)
+                .major(Major.COMPUTER_SCIENCE)
+                .build();
+
+        // 데이터베이스에 저장
+        memberRepository.save(testMember);
+
+        // 테스트용 Access Token 및 Refresh Token 생성
+        String accessToken = tokenProvider.generateTestAccessToken(testMember);
+        String refreshToken = tokenProvider.generateTestRefreshToken(testMember);
+
+        return new TestTokens(accessToken, refreshToken);
+    }
+
+    public static class TestTokens {
+
+        private final String accessToken;
+        private final String refreshToken;
+
+        public TestTokens(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#65 

### 📝 작업 내용
- Security Config 경로 설정
- TokenAuthenticationFilter 경로 설정
- JWT 토큰을 1개 -> 3개로 변경하여 인증 강화
- 테스트 유저 생성

### 📷 스크린샷 (선택)
[테스트 유저]
![화면 캡처 2025-03-31 022010](https://github.com/user-attachments/assets/5be1febd-452f-4852-9660-ba55c6133f85)
![화면 캡처 2025-03-31 022035](https://github.com/user-attachments/assets/0f859f30-8cbf-4fc7-bfef-a3320485223b)

[일반 유저]
![화면 캡처 2025-03-31 022135](https://github.com/user-attachments/assets/6792b5aa-0706-4221-88c7-982129b97055)
![화면 캡처 2025-03-31 022205](https://github.com/user-attachments/assets/3793d20c-6fac-4158-9cec-c0ed580959ca)

### 💬 리뷰 요구사항 (선택)
테스트 유저는 쿼리문을 이용해서 직접 DB에 저장하도록 구현했습니다. API 호출 시, accessToken, RefreshToken이 반환되므로 자유롭게 테스트 해보시면 됩니다. 유효 기간 넉넉합니다 ㅎㅎ

그리고 기존에는 @AuthenticationPrincipal Member member 를 이용해서 유저의 정보를 받아왔는데, @AuthenticationPrincipal CustomMemberDetails memberDetails 로 바뀌면서 JWT 인증 절차가 늘어났습니다.
참고로 소그인 테스트는 현재 로컬만 가능합니다!!
1. 카카오 소셜 로그인 진행 -> 초기 JWT 생성(프로필 등록 시 사용하며 @AuthenticationPrincipal MinimalMemberDetails memberDetails로 호출합니다.)
2. 프로필 등록 진행 -> 최종 JWT 생성(유저의 최종 정보가 담겨있으며 다른 API에서 호출할 때 사용합니다. @AuthenticationPrincipal CustomMemberDetails memberDetails로 호출합니다.)


이해 안 가는 부분 있다면 언제든지 질문하십쇼🫡
