### PR TITLE
쿠폰 기능 구현 

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
-    private static final int COUPON_COUNT = 100;
+    private static final int COUPON_COUNT = 1000;
     private static final int COUPON_LENGTH = 6;
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -29,7 +29,7 @@ public class CouponService {
 
         coupon.useCoupon();
         coupon.assignToMember(member);
-        member.setMaximumTicket(3);
+        member.increaseMaximumTicket(3);
         member.setRemainingTicket(member.getMaximumTicket());
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -29,7 +29,7 @@ public class CouponService {
 
         coupon.useCoupon();
         coupon.assignToMember(member);
-        member.increaseMaximumTicket(3);
+        member.increaseMaximumTicket();
         member.setRemainingTicket(member.getMaximumTicket());
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -4,6 +4,10 @@ import com.gobongbob.festamate.domain.coupon.domain.Coupon;
 import com.gobongbob.festamate.domain.coupon.dto.request.UseCouponRequest;
 import com.gobongbob.festamate.domain.coupon.persistence.CouponRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,5 +29,33 @@ public class CouponService {
 
         coupon.useCoupon();
         member.setMaximumTicket(3);
+    }
+
+    @Transactional
+    public void initializeCoupons(Member member) {
+        // 요청자가 관리자인지 확인하는 로직 필요
+
+        Set<Coupon> coupons = new HashSet<>();
+        while (coupons.size() < COUPON_COUNT) {
+            String code = generateRandomCode();
+            coupons.add(
+                    Coupon.builder()
+                            .code(code)
+                            .expiresAt(LocalDateTime.now().plusDays(100))
+                            .build()
+            );
+        }
+        couponRepository.saveAll(coupons);
+    }
+
+    private String generateRandomCode() {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder(COUPON_LENGTH);
+        for (int i = 0; i < COUPON_LENGTH; i++) {
+            sb.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+        }
+        System.out.println("Coupon Code = " + sb);
+
+        return sb.toString();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -28,6 +28,7 @@ public class CouponService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
 
         coupon.useCoupon();
+        coupon.assignToMember(member);
         member.setMaximumTicket(3);
         member.setRemainingTicket(member.getMaximumTicket());
     }

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -29,6 +29,7 @@ public class CouponService {
 
         coupon.useCoupon();
         member.setMaximumTicket(3);
+        member.setRemainingTicket(member.getMaximumTicket());
     }
 
     @Transactional

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/application/CouponService.java
@@ -1,0 +1,29 @@
+package com.gobongbob.festamate.domain.coupon.application;
+
+import com.gobongbob.festamate.domain.coupon.domain.Coupon;
+import com.gobongbob.festamate.domain.coupon.dto.request.UseCouponRequest;
+import com.gobongbob.festamate.domain.coupon.persistence.CouponRepository;
+import com.gobongbob.festamate.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private static final int COUPON_COUNT = 100;
+    private static final int COUPON_LENGTH = 6;
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    @Transactional
+    public void useCoupon(Member member, UseCouponRequest request) {
+        Coupon coupon = couponRepository.findByCode(request.code())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+
+        coupon.useCoupon();
+        member.setMaximumTicket(3);
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/domain/Coupon.java
@@ -37,6 +37,10 @@ public class Coupon {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    public void assignToMember(Member member) {
+        this.member = member;
+    }
+
     public void useCoupon() {
         if (this.used) {
             throw new IllegalStateException("이미 사용된 쿠폰입니다.");

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/domain/Coupon.java
@@ -1,0 +1,49 @@
+package com.gobongbob.festamate.domain.coupon.domain;
+
+import com.gobongbob.festamate.domain.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String code;
+
+    @Builder.Default
+    private boolean used = false;
+
+    private LocalDateTime expiresAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public void useCoupon() {
+        if (this.used) {
+            throw new IllegalStateException("이미 사용된 쿠폰입니다.");
+        }
+        if (LocalDateTime.now().isAfter(this.expiresAt)) {
+            throw new IllegalStateException("만료된 쿠폰입니다.");
+        }
+        this.used = true;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/dto/request/UseCouponRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/dto/request/UseCouponRequest.java
@@ -1,0 +1,5 @@
+package com.gobongbob.festamate.domain.coupon.dto.request;
+
+public record UseCouponRequest(String code) {
+
+}

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/persistence/CouponRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/persistence/CouponRepository.java
@@ -1,0 +1,12 @@
+package com.gobongbob.festamate.domain.coupon.persistence;
+
+import com.gobongbob.festamate.domain.coupon.domain.Coupon;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    @Query("select c from Coupon c where c.code = ?1")
+    Optional<Coupon> findByCode(String code);
+}

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
@@ -1,0 +1,30 @@
+package com.gobongbob.festamate.domain.coupon.presentation;
+
+import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
+import com.gobongbob.festamate.domain.coupon.application.CouponService;
+import com.gobongbob.festamate.domain.coupon.dto.request.UseCouponRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @PostMapping("")
+    public ResponseEntity<Void> useCoupon(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
+            @RequestBody UseCouponRequest request
+    ) {
+        couponService.useCoupon(memberDetails.getMember(), request);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
@@ -27,4 +27,13 @@ public class CouponController {
 
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/init")
+    public ResponseEntity<Void> initializeCoupons(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails
+    ) {
+        couponService.initializeCoupons(memberDetails.getMember());
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -88,8 +88,8 @@ public class Member {
         this.remainingTicket = maximumTicket;
     }
 
-    public void setMaximumTicket(int maximumTicket) {
-        this.maximumTicket = maximumTicket;
+    public void increaseMaximumTicket() {
+        this.maximumTicket++;
     }
 
     public boolean isHost(Room room) {

--- a/src/main/java/com/gobongbob/festamate/domain/report/domain/Report.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/domain/Report.java
@@ -2,10 +2,22 @@ package com.gobongbob.festamate.domain.report.domain;
 
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Room;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -13,6 +25,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,6 +45,7 @@ public class Report {
     private LocalDateTime reportDate;
 
     @Column
+    @Builder.Default
     private Boolean processed = false;
 
     public void markAsProcessed() {


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#90 

### 📝 작업 내용
- 쿠폰 엔티티 구현
- 초기 쿠폰 초기화 기능 구현
- 쿠폰 사용 기능 구현
  - 쿠폰 사용시, 회원의 티켓 한도가 3으로 증가됨
  - 또한 보유중인 티켓이 한도까지 모두 채워짐

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

