### PR TITLE
전역 예외 처리 핸들러를 구현합니다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.google.firebase:firebase-admin:9.2.0' // Firebase Admin SDK
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
@@ -4,11 +4,14 @@ package com.gobongbob.festamate.domain.auth.jwt.application;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +23,7 @@ public class CustomMemberDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         //UserDetails에 담아서 return하면 AutneticationManager가 검증 함
         Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 유저를 찾을 수 없습니다: " + loginId));
+                .orElseThrow(() -> new BadRequestException(USER_NOT_FOUND));
 
         return new CustomMemberDetails(member);
     }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/RefreshJwtTokenService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/RefreshJwtTokenService.java
@@ -2,8 +2,11 @@ package com.gobongbob.festamate.domain.auth.jwt.application;
 
 import com.gobongbob.festamate.domain.auth.jwt.domain.RefreshJwtToken;
 import com.gobongbob.festamate.domain.auth.jwt.persistence.RefreshTokenRepository;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.UNEXPECTED_TOKEN;
 
 // RefreshTokenRepository를 사용하여 데이터베이스에서 리프레시 토큰을 조회하며, 자체 JWT 리프레시 토큰을 관리함
 @RequiredArgsConstructor
@@ -14,6 +17,6 @@ public class RefreshJwtTokenService {
 
     public RefreshJwtToken findByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected token"));
+                .orElseThrow(() -> new BadRequestException(UNEXPECTED_TOKEN));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -4,9 +4,11 @@ import com.gobongbob.festamate.domain.auth.jwt.application.TokenService;
 import com.gobongbob.festamate.domain.auth.jwt.dto.request.CreateAccessTokenRequest;
 import com.gobongbob.festamate.domain.auth.jwt.dto.response.CreateAccessTokenResponse;
 import com.gobongbob.festamate.global.util.TokenProvider;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 // 자체 JWT 토큰을 생성하고 반환함
 @RequiredArgsConstructor
 @RestController
+@Validated
 @RequestMapping("/api/auth")
 public class TokenController {
 
@@ -23,7 +26,7 @@ public class TokenController {
 
     @PostMapping("/refresh") // 초기 refresh jwt로 access jwt 받아옴
     public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(
-            @RequestBody CreateAccessTokenRequest request) {
+            @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewInitialAccessToken(request.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -32,7 +35,7 @@ public class TokenController {
 
     @PostMapping("/refresh/final") // 최종 refresh jwt로 access jwt 받아옴
     public ResponseEntity<CreateAccessTokenResponse> createNewFinalAccessToken(
-            @RequestBody CreateAccessTokenRequest request) {
+            @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewFinalAccessToken(request.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -41,7 +44,7 @@ public class TokenController {
 
     @PostMapping("/refresh/test") // 테스트용 refresh jwt로 access jwt 받아옴
     public ResponseEntity<CreateAccessTokenResponse> createNewTestAccessToken(
-            @RequestBody CreateAccessTokenRequest request) {
+            @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewTestAccessToken(request.getRefreshToken());
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -3,11 +3,10 @@ package com.gobongbob.festamate.domain.auth.jwt.presentation;
 import com.gobongbob.festamate.domain.auth.jwt.application.TokenService;
 import com.gobongbob.festamate.domain.auth.jwt.dto.request.CreateAccessTokenRequest;
 import com.gobongbob.festamate.domain.auth.jwt.dto.response.CreateAccessTokenResponse;
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import com.gobongbob.festamate.global.util.TokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,29 +24,26 @@ public class TokenController {
     private final TokenProvider tokenProvider;
 
     @PostMapping("/refresh") // 초기 refresh jwt로 access jwt 받아옴
-    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(
+    public SuccessResponse<CreateAccessTokenResponse> createNewAccessToken(
             @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewInitialAccessToken(request.getRefreshToken());
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CreateAccessTokenResponse(newAccessToken));
+        return new SuccessResponse<>(new CreateAccessTokenResponse(newAccessToken));
     }
 
     @PostMapping("/refresh/final") // 최종 refresh jwt로 access jwt 받아옴
-    public ResponseEntity<CreateAccessTokenResponse> createNewFinalAccessToken(
+    public SuccessResponse<CreateAccessTokenResponse> createNewFinalAccessToken(
             @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewFinalAccessToken(request.getRefreshToken());
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CreateAccessTokenResponse(newAccessToken));
+        return new SuccessResponse<>(new CreateAccessTokenResponse(newAccessToken));
     }
 
     @PostMapping("/refresh/test") // 테스트용 refresh jwt로 access jwt 받아옴
-    public ResponseEntity<CreateAccessTokenResponse> createNewTestAccessToken(
+    public SuccessResponse<CreateAccessTokenResponse> createNewTestAccessToken(
             @RequestBody @Valid CreateAccessTokenRequest request) {
         String newAccessToken = tokenService.createNewTestAccessToken(request.getRefreshToken());
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new CreateAccessTokenResponse(newAccessToken));
+        return new SuccessResponse<>(new CreateAccessTokenResponse(newAccessToken));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.auth.oauth.presentation;
 
 import com.gobongbob.festamate.domain.auth.oauth.application.OauthService;
 import com.gobongbob.festamate.domain.auth.oauth.dto.request.LoginRequest;
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
@@ -32,25 +33,27 @@ public class OauthController {
     // @PostMapping을 통해 request로 인가 코드를 전달하고, response로 액세스 토큰을 받아옴
     // 수동으로 인가 코드를 전달받아 처리 (테스트용으로 추후 삭제 가능)
     @PostMapping("/api/auth/kakao")
-    public ResponseEntity<Map<String, String>> kakaoLogin(@RequestBody @Valid LoginRequest loginRequest,
-            HttpServletRequest request,
-            HttpServletResponse response) {
+    public SuccessResponse<Map<String, String>> kakaoLogin(
+            @RequestBody @Valid LoginRequest loginRequest,
+           HttpServletRequest request,
+           HttpServletResponse response) {
         // 인가 코드 처리
         Map<String, String> tokens = oauthService.kakaoLogin(loginRequest.getCode(), request,
                 response);
-        return ResponseEntity.ok(tokens);
+        return new SuccessResponse<>(tokens);
     }
 
     // 리다이렉트 URI에서 인가 코드를 자동으로 처리(운영용)
     @GetMapping("/login/oauth2/code/kakao")
-    public ResponseEntity<Map<String, String>> handleKakaoRedirect(@RequestParam String code,
+    public SuccessResponse<Map<String, String>> handleKakaoRedirect(
+            @RequestParam String code,
             HttpServletRequest request,
             HttpServletResponse response) {
         // 전달받은 인가 코드를 서비스로 넘겨 처리
         Map<String, String> tokens = oauthService.kakaoLogin(code, request, response);
 
         // 성공 시 JWT 토큰 반환
-        return ResponseEntity.ok(tokens);
+        return new SuccessResponse<>(tokens);
     }
 
     @Value("${KAKAO_CLIENT_ID}")

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -5,9 +5,12 @@ import com.gobongbob.festamate.domain.auth.oauth.dto.request.LoginRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +22,7 @@ import org.springframework.web.servlet.view.RedirectView;
 // 인가 코드를 받아 OauthService의 kakaoLogin 메서드를 호출하고, 인가 코드를 사용하여 액세스 토큰을 요청 후 사용자 정보를 가져와 처리함
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping
 public class OauthController {
@@ -28,7 +32,7 @@ public class OauthController {
     // @PostMapping을 통해 request로 인가 코드를 전달하고, response로 액세스 토큰을 받아옴
     // 수동으로 인가 코드를 전달받아 처리 (테스트용으로 추후 삭제 가능)
     @PostMapping("/api/auth/kakao")
-    public ResponseEntity<Map<String, String>> kakaoLogin(@RequestBody LoginRequest loginRequest,
+    public ResponseEntity<Map<String, String>> kakaoLogin(@RequestBody @Valid LoginRequest loginRequest,
             HttpServletRequest request,
             HttpServletResponse response) {
         // 인가 코드 처리

--- a/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
@@ -8,12 +8,17 @@ import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.presentation.RoomParticipantRepository;
 import java.time.LocalDateTime;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.CHAT_ROOM_NOT_FOUND;
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_AUTHORITY_CHAT_ROOM;
 
 @Service
 @Transactional(readOnly = true)
@@ -28,7 +33,7 @@ public class ChatService {
     @Transactional
     public void sendMessage(Long roomId, Member member, String message) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(CHAT_ROOM_NOT_FOUND));
 
         Message savedMessage = messageRepository.save(
                 Message.builder()
@@ -52,7 +57,7 @@ public class ChatService {
 
     private void validateRoomParticipation(Long memberId, Long roomId) {
         if (roomParticipantRepository.findByRoom_IdAndMember_Id(memberId, roomId).isEmpty()) {
-            throw new IllegalArgumentException("채팅방을 조회할 수 있는 권한이 없습니다.");
+            throw new BadRequestException(NO_AUTHORITY_CHAT_ROOM);
         }
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -5,6 +5,7 @@ import com.gobongbob.festamate.domain.chat.application.ChatService;
 import com.gobongbob.festamate.domain.chat.dto.request.MessageRequest;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -25,9 +26,8 @@ public class ChatController {
 
     private final ChatService chatService;
 
-
     @MessageMapping("/chat/room/{roomId}") // Spring App 을 거쳐서 메시지 전송. 앞에 "app" prefix 를 붙여야 함
-    public ResponseEntity<Void> sendMessage(
+    public SuccessResponse<Void> sendMessage(
             @DestinationVariable Long roomId,
             Authentication authentication,
             MessageRequest request
@@ -35,17 +35,17 @@ public class ChatController {
         Member member = ((CustomMemberDetails) authentication.getPrincipal()).getMember();
         chatService.sendMessage(roomId, member, request.message());
 
-        return ResponseEntity.noContent().build();
+        return new SuccessResponse<>();
     }
 
     @GetMapping("api/messages/room/{roomId}")
-    public ResponseEntity<Slice<MessageResponse>> findMessages(
+    public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal Member member,
             @PathVariable Long roomId,
             @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(member.getId(), roomId, pageable);
 
-        return ResponseEntity.ok(messages);
+        return new SuccessResponse<>(messages);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/coupon/presentation/CouponController.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.domain.coupon.presentation;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.coupon.application.CouponService;
 import com.gobongbob.festamate.domain.coupon.dto.request.UseCouponRequest;
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,21 +20,21 @@ public class CouponController {
     private final CouponService couponService;
 
     @PostMapping("")
-    public ResponseEntity<Void> useCoupon(
+    public SuccessResponse<Void> useCoupon(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @RequestBody UseCouponRequest request
     ) {
         couponService.useCoupon(memberDetails.getMember(), request);
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @PostMapping("/init")
-    public ResponseEntity<Void> initializeCoupons(
+    public SuccessResponse<Void> initializeCoupons(
             @AuthenticationPrincipal CustomMemberDetails memberDetails
     ) {
         couponService.initializeCoupons(memberDetails.getMember());
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/application/OcrService.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
@@ -22,6 +24,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.EMPTY_FILE;
 
 @Service
 @Transactional
@@ -39,7 +43,7 @@ public class OcrService {
     public StudentInfoResponse checkStudentCard(MultipartFile file, Member member) throws IOException {
         // 파일이 비어있거나 null인 경우 예외 처리
         if (file == null || file.isEmpty()) {
-            throw new IllegalArgumentException("파일이 비어있습니다.");
+            throw new BadRequestException(EMPTY_FILE);
         }
 
         // 임시 파일로 저장

--- a/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/presentation/OcrController.java
@@ -4,8 +4,9 @@ import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.image.application.OcrService;
 import com.gobongbob.festamate.domain.image.dto.response.StudentInfoResponse;
 import java.io.IOException;
+
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,10 +22,10 @@ public class OcrController {
     private final OcrService ocrService;
 
     @PostMapping("/api/check/student-card")
-    public ResponseEntity<StudentInfoResponse> checkStudentCard(
+    public SuccessResponse<StudentInfoResponse> checkStudentCard(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @RequestParam("file") MultipartFile file
     ) throws IOException {
-        return ResponseEntity.ok(ocrService.checkStudentCard(file, memberDetails.getMember()));
+        return new SuccessResponse<>(ocrService.checkStudentCard(file, memberDetails.getMember()));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -8,9 +8,14 @@ import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import java.util.List;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.DUPLICATE_NICKNAME;
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_MEMBER;
 
 @Service
 @Transactional(readOnly = true)
@@ -36,12 +41,12 @@ public class MemberService {
     public MemberResponse findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .map(MemberResponse::fromEntity)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
 
     public Member findMembersById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() ->  new BadRequestException(NO_MEMBER));
     }
 
     public MemberProfileResponse findProfile(Member member) {
@@ -56,7 +61,7 @@ public class MemberService {
     @Transactional
     public void deleteMemberById(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() ->  new BadRequestException(NO_MEMBER));
 
         /**
          * 1. 삭제하려는 사용자가 로그인한 사용자와 같은지 확인하는 로직 필요
@@ -74,7 +79,7 @@ public class MemberService {
         checkNicknameDuplication(request.nickname()); // 프로필 등록 중 닉네임 중복 확인 필요함
 
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
+                .orElseThrow(() ->  new BadRequestException(NO_MEMBER));
 
         Member registeredMember = request.toEntity(member); // 기존 Member 정보 그대로 사용
         memberRepository.save(registeredMember);
@@ -86,14 +91,14 @@ public class MemberService {
         boolean isDuplicate = memberRepository.existsByNickname(nickname);
 
         if (isDuplicate) {
-            throw new IllegalArgumentException("중복된 닉네임입니다.");
+            throw new BadRequestException(DUPLICATE_NICKNAME);
         }
     }
 
     // 아래부터는 oauth2를 위한 메서드
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected member"));
+                .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
 
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Gender.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Gender.java
@@ -1,7 +1,11 @@
 package com.gobongbob.festamate.domain.member.domain;
 
 import java.util.Arrays;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.Getter;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_GENDER;
 
 @Getter
 public enum Gender {
@@ -19,6 +23,6 @@ public enum Gender {
         return Arrays.stream(Gender.values())
                 .filter(gender -> gender.name.equals(name))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 성별이 없습니다."));
+                .orElseThrow(() -> new BadRequestException(NO_GENDER));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.gobongbob.festamate.domain.auth.oauth.domain.OauthInfo;
 import com.gobongbob.festamate.domain.image.domain.ProfileImage;
 import com.gobongbob.festamate.domain.major.domain.Major;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -24,6 +25,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.NOT_ENOUGH_TICKET;
 
 @Entity
 @Getter
@@ -109,7 +112,7 @@ public class Member {
         if (this.remainingTicket > 0) {
             this.remainingTicket--;
         } else {
-            throw new IllegalStateException("티켓이 부족합니다.");
+            throw new BadRequestException(NOT_ENOUGH_TICKET);
         }
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
@@ -12,9 +12,12 @@ import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import java.util.List;
 import java.util.Map;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 public class MemberController {
 
@@ -32,7 +36,7 @@ public class MemberController {
     private final TokenService tokenService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<Void> signUp(@RequestBody MemberCreateRequest request) {
+    public ResponseEntity<Void> signUp(@RequestBody @Valid MemberCreateRequest request) {
         Member member = memberService.createMember(request);
 
         return ResponseEntity.ok().build();
@@ -58,7 +62,7 @@ public class MemberController {
     @PatchMapping("/members/profile")
     public ResponseEntity<Void> updateProfile(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
-            @RequestBody ProfileUpdateRequest request
+            @RequestBody @Valid ProfileUpdateRequest request
     ) {
         memberService.updateMemberProfileById(memberDetails.getMember(), request);
 
@@ -75,7 +79,7 @@ public class MemberController {
     // 프로필 등록 API
     @PostMapping("/api/auth/register/profile") // 추후 /api/auth를 상위 경로에 작성하도록 변경 필요
     public ResponseEntity<Map<String, String>> registerProfile(
-            @RequestBody ProfileRegisterRequest request,
+            @RequestBody @Valid ProfileRegisterRequest request,
             @AuthenticationPrincipal MinimalMemberDetails memberDetails) { // 최소 JWT 정보
 
         Long userId = memberDetails.getId();

--- a/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/presentation/MemberController.java
@@ -13,6 +13,7 @@ import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import java.util.List;
 import java.util.Map;
 
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,49 +37,48 @@ public class MemberController {
     private final TokenService tokenService;
 
     @PostMapping("/auth/signup")
-    public ResponseEntity<Void> signUp(@RequestBody @Valid MemberCreateRequest request) {
+    public SuccessResponse<Void> signUp(@RequestBody @Valid MemberCreateRequest request) {
         Member member = memberService.createMember(request);
-
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @GetMapping("/members")
-    public ResponseEntity<List<MemberResponse>> findAllMembers() {
-        return ResponseEntity.ok(memberService.findAllMembers());
+    public SuccessResponse<List<MemberResponse>> findAllMembers() {
+        return new SuccessResponse<>(memberService.findAllMembers());
     }
 
     @GetMapping("/members/{memberId}")
-    public ResponseEntity<MemberResponse> findMemberById(@PathVariable Long memberId) {
-        return ResponseEntity.ok(memberService.findMemberById(memberId));
+    public SuccessResponse<MemberResponse> findMemberById(@PathVariable Long memberId) {
+        return new SuccessResponse<>(memberService.findMemberById(memberId));
     }
 
     @GetMapping("/api/auth/members/profile")
-    public ResponseEntity<MemberProfileResponse> getProfile(
+    public SuccessResponse<MemberProfileResponse> getProfile(
             @AuthenticationPrincipal CustomMemberDetails memberDetails
     ) {
-        return ResponseEntity.ok(memberService.findProfile(memberDetails.getMember()));
+        return new SuccessResponse<>(memberService.findProfile(memberDetails.getMember()));
     }
 
     @PatchMapping("/members/profile")
-    public ResponseEntity<Void> updateProfile(
+    public SuccessResponse<Void> updateProfile(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @RequestBody @Valid ProfileUpdateRequest request
     ) {
         memberService.updateMemberProfileById(memberDetails.getMember(), request);
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @DeleteMapping("/members/{memberId}")
-    public ResponseEntity<Void> deleteMemberById(@PathVariable Long memberId) {
+    public SuccessResponse<Void> deleteMemberById(@PathVariable Long memberId) {
         memberService.deleteMemberById(memberId);
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     // 프로필 등록 API
     @PostMapping("/api/auth/register/profile") // 추후 /api/auth를 상위 경로에 작성하도록 변경 필요
-    public ResponseEntity<Map<String, String>> registerProfile(
+    public SuccessResponse<Map<String, String>> registerProfile(
             @RequestBody @Valid ProfileRegisterRequest request,
             @AuthenticationPrincipal MinimalMemberDetails memberDetails) { // 최소 JWT 정보
 
@@ -89,13 +89,13 @@ public class MemberController {
         Map<String, String> tokens = tokenService.generateTokens(userId);
 
         // 최종 JWT 반환
-        return ResponseEntity.ok(tokens);
+        return new SuccessResponse<>(tokens);
     }
 
     // 닉네임 중복 확인 API
     @GetMapping("/api/auth/register/check/nickname")
-    public ResponseEntity<String> checkNickname(@RequestParam String nickname) {
+    public SuccessResponse<String> checkNickname(@RequestParam String nickname) {
         memberService.checkNicknameDuplication(nickname);
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/report/application/ReportService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/application/ReportService.java
@@ -10,9 +10,13 @@ import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 @Service
 @Transactional
@@ -26,11 +30,11 @@ public class ReportService {
     // 신고하기
     public void reportRoom(Member reporter, Long roomId, ReportRoomRequest request) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("신고할 방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
 
         // 자신의 방은 신고할 수 없음
         if (room.getHost().getId().equals(reporter.getId())) {
-            throw new IllegalArgumentException("자신의 방은 신고할 수 없습니다.");
+            throw new BadRequestException(CAN_NOT_REPORT_MYSELF);
         }
 
         // 이미 신고한 방인지 확인
@@ -38,7 +42,7 @@ public class ReportService {
                 .stream()
                 .findAny()
                 .ifPresent(report -> {
-                    throw new IllegalArgumentException("이미 신고한 방입니다.");
+                    throw new BadRequestException(ALREADY_REPORT);
                 });
 
         Report report = request.toEntity(reporter, room);
@@ -71,7 +75,7 @@ public class ReportService {
     // 신고 처리
     public void processReport(Long reportId) {
         Report report = reportRepository.findById(reportId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 신고가 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NO_REPORT));
 
         report.markAsProcessed();
         reportRepository.save(report);

--- a/src/main/java/com/gobongbob/festamate/domain/report/domain/ReportReason.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/domain/ReportReason.java
@@ -1,5 +1,9 @@
 package com.gobongbob.festamate.domain.report.domain;
 
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_REPORT_REASON;
+
 public enum ReportReason {
     UNHEALTHY("음란물/불건전한 만남 및 대화"),
     ABUSE("욕설/비하"),
@@ -21,6 +25,6 @@ public enum ReportReason {
                 return reason;
             }
         }
-        throw new IllegalArgumentException("해당하는 신고 사유가 없습니다.");
+        throw new BadRequestException(NO_REPORT_REASON);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/presentation/ReportController.java
@@ -6,6 +6,7 @@ import com.gobongbob.festamate.domain.report.dto.request.ReportRoomRequest;
 import com.gobongbob.festamate.domain.report.dto.response.ReportRoomResponse;
 import java.util.List;
 
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,28 +29,28 @@ public class ReportController {
     private final ReportService reportService;
 
     @PostMapping("/{roomId}")
-    public ResponseEntity<Void> reportRoom(
+    public SuccessResponse<Void> reportRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId,
             @RequestBody @Valid ReportRoomRequest request
     ) {
         reportService.reportRoom(memberDetails.getMember(), roomId, request);
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @GetMapping("")
-    public ResponseEntity<List<ReportRoomResponse>> getAllReports() {
-        return ResponseEntity.ok(reportService.getAllReports());
+    public SuccessResponse<List<ReportRoomResponse>> getAllReports() {
+        return new SuccessResponse<>(reportService.getAllReports());
     }
 
     @GetMapping("/unprocessed")
-    public ResponseEntity<List<ReportRoomResponse>> getUnprocessedReports() {
-        return ResponseEntity.ok(reportService.getUnprocessedReports());
+    public SuccessResponse<List<ReportRoomResponse>> getUnprocessedReports() {
+        return new SuccessResponse<>(reportService.getUnprocessedReports());
     }
 
     @PatchMapping("/{reportId}/process")
-    public ResponseEntity<Void> processReport(@PathVariable Long reportId) {
+    public SuccessResponse<Void> processReport(@PathVariable Long reportId) {
         reportService.processReport(reportId);
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/presentation/ReportController.java
@@ -5,9 +5,12 @@ import com.gobongbob.festamate.domain.report.application.ReportService;
 import com.gobongbob.festamate.domain.report.dto.request.ReportRoomRequest;
 import com.gobongbob.festamate.domain.report.dto.response.ReportRoomResponse;
 import java.util.List;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/report")
 public class ReportController {
@@ -27,7 +31,7 @@ public class ReportController {
     public ResponseEntity<Void> reportRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId,
-            @RequestBody ReportRoomRequest request
+            @RequestBody @Valid ReportRoomRequest request
     ) {
         reportService.reportRoom(memberDetails.getMember(), roomId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -6,9 +6,12 @@ import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.domain.room.presentation.RoomParticipantRepository;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -22,7 +25,7 @@ public class RoomParticipationService {
     @Transactional
     public void participateRoom(Member member, Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
 
 //        validateRoomParticipation(member.getId());
         validateRoomFull(room.getId());
@@ -35,7 +38,7 @@ public class RoomParticipationService {
     @Transactional
     public void leaveRoomById(Member member, Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateNotHost(room, member);
 
         roomParticipantRepository.deleteByMember_Id(member.getId());
@@ -43,7 +46,7 @@ public class RoomParticipationService {
 
     public boolean isMemberHost(Long roomId, Long memberId) {
         return roomParticipantRepository.findByRoom_IdAndMember_Id(roomId, memberId)
-                .orElseThrow(() -> new IllegalArgumentException("참여중인 모임방이 존재하지 않습니다."))
+                .orElseThrow(() -> new BadRequestException(NO_PARTICIPATING_ROOM))
                 .isHost();
     }
 
@@ -52,23 +55,23 @@ public class RoomParticipationService {
                 .stream()
                 .findFirst()
                 .ifPresent(roomParticipant -> {
-                    throw new IllegalArgumentException("이미 모임방에 참여하고 있습니다.");
+                    throw new BadRequestException(ALREADY_PARTICIPATING);
                 });
     }
 
     private void validateRoomFull(Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         int participantsCount = roomParticipantRepository.countByRoom_Id(roomId);
 
         if (room.getMaxParticipants() == participantsCount) {
-            throw new IllegalArgumentException("모임방이 꽉 찼습니다.");
+            throw new BadRequestException(FULL_ROOM);
         }
     }
 
     private void validateNotHost(Room room, Member member) {
         if (member.isHost(room)) {
-            throw new IllegalArgumentException("일반 회원이어야 합니다.");
+            throw new BadRequestException(MUST_NORMAL);
         }
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -16,12 +16,16 @@ import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.domain.room.presentation.RoomParticipantRepository;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -83,13 +87,13 @@ public class RoomService {
                 .map(room -> {
                     List<RoomParticipant> roomParticipants = roomParticipantRepository.findByRoom_Id(room.getId());
                     return RoomResponse.fromEntity(room, roomParticipants);
-                }).orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                }).orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
     }
 
     @Transactional
     public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
         validateAlone(room);
 
@@ -105,7 +109,7 @@ public class RoomService {
     @Transactional
     public void deleteRoomById(Member member, Long roomId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("모임방이 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
 
         roomParticipantRepository.deleteByRoom(room);
@@ -121,20 +125,21 @@ public class RoomService {
                 .stream()
                 .findFirst()
                 .ifPresent(roomParticipant -> {
-                    throw new IllegalArgumentException("이미 모임방에 참여하고 있습니다.");
+                    throw new BadRequestException(ALREADY_PARTICIPATING);
                 });
     }
 
     private void validateIsHost(Room room, Member member) {
         if (!member.isHost(room)) {
-            throw new IllegalArgumentException("방장이어야 합니다.");
+            throw new BadRequestException(MUST_HOST);
+
         }
     }
 
     private void validateAlone(Room room) {
         int participantsCount = roomParticipantRepository.countByRoom_Id(room.getId());
         if (participantsCount > 1) {
-            throw new IllegalArgumentException("방에 방장을 제외한 다른 사용자가 입장한 상태에서는 수정할 수 없습니다.");
+            throw new BadRequestException(CAN_NOT_UPDATE);
         }
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 public record RoomCreateRequest(
-        String title,
-        String content,
+        @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다") String title,
+        @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
         String preferredGender,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
@@ -3,11 +3,13 @@ package com.gobongbob.festamate.domain.room.dto.request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import jakarta.validation.constraints.Size;
+
 import java.time.LocalDateTime;
 
 public record RoomUpdateRequest(
-        String title,
-        String content,
+        @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다") String title,
+        @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
         String preferredGender,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -11,6 +11,7 @@ import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import java.util.List;
 
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -42,7 +43,7 @@ public class RoomController {
     private final ChatService chatService;
 
     @PostMapping("")
-    public ResponseEntity<Void> createRoom(
+    public SuccessResponse<Void> createRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @RequestPart("request") @Valid RoomCreateRequest request,
             @RequestPart(value = "imageFiles", required = false) List<MultipartFile> multipartFiles
@@ -54,51 +55,51 @@ public class RoomController {
                 "안녕하세요! " + createdRoom.getTitle() + "에 오신 것을 환영합니다!"
         );
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @GetMapping("")
-    public ResponseEntity<Page<RoomListResponse>> findAllRooms(
+    public SuccessResponse<Page<RoomListResponse>> findAllRooms(
             @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(roomService.findAllRooms(pageable));
+        return new SuccessResponse<>(roomService.findAllRooms(pageable));
     }
 
     @GetMapping("/participate")
-    public ResponseEntity<List<RoomListResponse>> findParticipatingRooms(
+    public SuccessResponse<List<RoomListResponse>> findParticipatingRooms(
             @AuthenticationPrincipal CustomMemberDetails memberDetails
     ) {
-        return ResponseEntity.ok(roomService.findParticipatingRooms(memberDetails.getMember().getId()));
+        return new SuccessResponse<>(roomService.findParticipatingRooms(memberDetails.getMember().getId()));
     }
 
     @GetMapping("/{roomId}")
-    public ResponseEntity<RoomResponse> findRoomById(@PathVariable Long roomId) {
-        return ResponseEntity.ok(roomService.findRoomById(roomId));
+    public SuccessResponse<RoomResponse> findRoomById(@PathVariable Long roomId) {
+        return new SuccessResponse<>(roomService.findRoomById(roomId));
     }
 
     @PatchMapping("/{roomId}")
-    public ResponseEntity<Void> updateRoomById(
+    public SuccessResponse<Void> updateRoomById(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId,
             @RequestBody @Valid RoomUpdateRequest request
     ) {
         roomService.updateRoomById(memberDetails.getMember(), roomId, request);
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @DeleteMapping("/{roomId}")
-    public ResponseEntity<Void> deleteRoomById(
+    public SuccessResponse<Void> deleteRoomById(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId
     ) {
         roomService.deleteRoomById(memberDetails.getMember(), roomId);
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @PostMapping("/{roomId}/participate")
-    public ResponseEntity<Void> participateRoom(
+    public SuccessResponse<Void> participateRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId
     ) {
@@ -109,11 +110,11 @@ public class RoomController {
                 memberDetails.getMember().getNickname() + "님이 들어왔습니다."
         );
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @PostMapping("/{roomId}/leave")
-    public ResponseEntity<Void> leaveRoom(
+    public SuccessResponse<Void> leaveRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId
     ) {
@@ -124,14 +125,14 @@ public class RoomController {
                 memberDetails.getMember().getNickname() + "님이 나갔습니다."
         );
 
-        return ResponseEntity.ok().build();
+        return new SuccessResponse<>();
     }
 
     @GetMapping("/{roomId}/isHost")
-    public ResponseEntity<Boolean> isMemberHost(
+    public SuccessResponse<Boolean> isMemberHost(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId
     ) {
-        return ResponseEntity.ok(roomParticipationService.isMemberHost(memberDetails.getMember().getId(), roomId));
+        return new SuccessResponse<>(roomParticipationService.isMemberHost(memberDetails.getMember().getId(), roomId));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -9,9 +9,12 @@ import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import java.util.List;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/rooms")
 public class RoomController {
@@ -33,7 +37,7 @@ public class RoomController {
     @PostMapping("")
     public ResponseEntity<Void> createRoom(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
-            @RequestBody RoomCreateRequest request
+            @RequestBody @Valid RoomCreateRequest request
     ) {
         Room createdRoom = roomService.createRoom(memberDetails.getMember(), request);
         chatService.sendMessage(
@@ -66,7 +70,7 @@ public class RoomController {
     public ResponseEntity<Void> updateRoomById(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable Long roomId,
-            @RequestBody RoomUpdateRequest request
+            @RequestBody @Valid RoomUpdateRequest request
     ) {
         roomService.updateRoomById(memberDetails.getMember(), roomId, request);
 

--- a/src/main/java/com/gobongbob/festamate/global/config/WebSocketInterceptor.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/WebSocketInterceptor.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.global.config;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import com.gobongbob.festamate.global.util.TokenProvider;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.USER_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
@@ -41,7 +44,7 @@ public class WebSocketInterceptor implements ChannelInterceptor {
 
             Long userId = tokenProvider.getUserId(token);
             Member member = memberRepository.findById(userId)
-                    .orElseThrow(() -> new IllegalArgumentException("No user found"));
+                    .orElseThrow(() -> new BadRequestException(USER_NOT_FOUND));
             UserDetails userDetails = new CustomMemberDetails(member);
 
             accessor.setUser(new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
@@ -8,7 +8,27 @@ public enum ResponseCode {
     SUCCESS(true, "요청에 성공하였습니다."),
     INTERNAL_SEVER_ERROR(false, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요."),
     INVALID_REQUEST(false, "올바르지 않은 요청입니다."),
-
+    NOT_FOUND_ROOM(false, "모임방이 존재하지 않습니다."),
+    ALREADY_PARTICIPATING(false, "이미 모임방에 참여하고 있습니다."),
+    NO_PARTICIPATING_ROOM(false, "참여중인 모임방이 존재하지 않습니다."),
+    FULL_ROOM(false, "모임방이 꽉 찼습니다."),
+    MUST_HOST(false, "방장이어야 합니다."),
+    MUST_NORMAL(false, "일반 회원이어야 합니다."),
+    CAN_NOT_UPDATE(false, "방에 방장을 제외한 다른 사용자가 입장한 상태에서는 수정할 수 없습니다."),
+    NO_GENDER(false, "해당하는 성별이 없습니다."),
+    EMPTY_FILE(false, "파일이 비어있습니다."),
+    UNEXPECTED_TOKEN(false, "올바르지 않은 토큰입니다."),
+    USER_NOT_FOUND(false, "해당 유저를 찾을 수 없습니다"),
+    CHAT_ROOM_NOT_FOUND(false, "채팅방이 존재하지 않습니다."),
+    NO_AUTHORITY_CHAT_ROOM(false, "채팅방을 조회할 수 있는 권한이 없습니다."),
+    NO_DEPARTMENT(false, "해당하는 학과가 존재하지 않습니다."),
+    NO_MEMBER(false, "사용자가 존재하지 않습니다."),
+    DUPLICATE_NICKNAME(false, "중복된 닉네임입니다."),
+    NOT_ENOUGH_TICKET(false, "티켓이 부족합니다."),
+    CAN_NOT_REPORT_MYSELF(false, "자신의 방은 신고할 수 없습니다."),
+    ALREADY_REPORT(false, "이미 신고한 방입니다."),
+    NO_REPORT(false, "해당 신고가 존재하지 않습니다."),
+    NO_REPORT_REASON(false, "해당하는 신고 사유가 없습니다."),
 
     EXCEED_IMAGE_CAPACITY(false, "업로드 가능한 이미지 용량을 초과했습니다.");
 

--- a/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
@@ -1,0 +1,22 @@
+package com.gobongbob.festamate.global.response;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+
+    SUCCESS(true, "요청에 성공하였습니다."),
+    INTERNAL_SEVER_ERROR(false, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요."),
+    INVALID_REQUEST(false, "올바르지 않은 요청입니다."),
+
+
+    EXCEED_IMAGE_CAPACITY(false, "업로드 가능한 이미지 용량을 초과했습니다.");
+
+    private final boolean isSuccess;
+    private final String message;
+
+    ResponseCode(boolean isSuccess, String message) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/global/response/SuccessResponse.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/SuccessResponse.java
@@ -1,0 +1,30 @@
+package com.gobongbob.festamate.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"isSuccess", "message", "result"})
+// 이 어노테이션을 클래스 레벨에 적용하여 JSON으로 변환될 때 필드들이 특정한 순서로 나타나도록 설정
+public class SuccessResponse<T> {
+
+    private final Boolean isSuccess;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)// 어노테이션이 적용된 필드가 null인 경우, JSON 응답에서 해당 필드는 제외
+    private T result;
+
+    // 일반적인 응답 형식
+    public SuccessResponse() {
+        this.isSuccess = ResponseCode.SUCCESS.isSuccess();
+        this.message = ResponseCode.SUCCESS.getMessage();
+    }
+
+    // 반환값이 필요한 응답 형식
+    public SuccessResponse(T result) {
+        this.isSuccess = ResponseCode.SUCCESS.isSuccess();
+        this.message = ResponseCode.SUCCESS.getMessage();
+        this.result = result;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/global/response/exception/BadRequestException.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package com.gobongbob.festamate.global.response.exception;
+
+
+import com.gobongbob.festamate.global.response.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class BadRequestException extends RuntimeException {
+
+    private final String message;
+
+    public BadRequestException(final ResponseCode responseCode) {
+        this.message = responseCode.getMessage();
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/global/response/exception/ExceptionResponse.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/exception/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package com.gobongbob.festamate.global.response.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ExceptionResponse {
+
+    private final Boolean isSuccess;
+    private final String message;
+}

--- a/src/main/java/com/gobongbob/festamate/global/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/exception/GlobalExceptionHandler.java
@@ -33,6 +33,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             WebRequest request
     ) {
         // 예외 메시지를 WARN 레벨로 로깅
+        log.warn(e.getMessage(), e);
 
         String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
         // BindingResult에서 첫 번째 FieldError의 DefaultMessage를 가져옵니다. 이후 FieldError가 null이 아님을 보장합니다.

--- a/src/main/java/com/gobongbob/festamate/global/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/exception/GlobalExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.gobongbob.festamate.global.response.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.EXCEED_IMAGE_CAPACITY;
+import static com.gobongbob.festamate.global.response.ResponseCode.INVALID_REQUEST;
+
+/**
+ * 전역 예외 처리기입니다.
+ * body로 클라이언트에게 유용한 피드백을 제공하면서, 로깅을 추가하여 서버 측에서도 문제를 효과적으로 추적할 수 있게 해줍니다.
+ * */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    // @Valid 어노테이션으로 검증 실패 시 발생하는 예외를 처리합니다. -> 보류
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, //발생한 예외 객체
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        // 예외 메시지를 WARN 레벨로 로깅
+
+        String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
+        // BindingResult에서 첫 번째 FieldError의 DefaultMessage를 가져옵니다. 이후 FieldError가 null이 아님을 보장합니다.
+
+        return ResponseEntity.badRequest() // HTTP 상태 코드 400으로 응답을 시작
+                .body(new ExceptionResponse(INVALID_REQUEST.isSuccess(), errMessage)); // 응답 body 생성
+    }
+
+    // 파일 업로드 크기 제한 초과 시 발생하는 예외를 처리합니다.
+    @ExceptionHandler(SizeLimitExceededException.class) // SizeLimitExceededException 클래스의 예외가 발생했을 때 이 메소드가 처리함을 명시
+    public ResponseEntity<ExceptionResponse> handleSizeLimitExceededException(SizeLimitExceededException e) {
+        log.warn(e.getMessage(), e);
+
+        String message = EXCEED_IMAGE_CAPACITY.getMessage()
+                + " 입력된 이미지 용량은 " + e.getActualSize() + " byte 입니다. "
+                + "(제한 용량: " + e.getPermittedSize() + " byte)";
+        return ResponseEntity.badRequest() // HTTP 상태 코드 400으로 응답
+                .body(new ExceptionResponse(EXCEED_IMAGE_CAPACITY.isSuccess(), message));
+    }
+
+     // 일반적인 잘못된 요청 예외를 처리합니다.
+    @ExceptionHandler(BadRequestException.class) // BadRequestException 클래스의 예외가 발생했을 때 이 메소드가 처리함을 명시
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(BadRequestException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest() // HTTP 상태 코드 400으로 응답
+                .body(new ExceptionResponse(INVALID_REQUEST.isSuccess(), e.getMessage()));
+    }
+
+}

--- a/src/main/java/com/gobongbob/festamate/testUser/TestController.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestController.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.testUser;
 
+import com.gobongbob.festamate.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,9 +15,9 @@ public class TestController {
     private final TestService testService;
 
     @PostMapping("/create")
-    public ResponseEntity<TestService.TestTokens> createTestMember() {
+    public SuccessResponse<TestService.TestTokens> createTestMember() {
         // 테스트용 유저 생성 및 JWT 토큰 반환
         TestService.TestTokens testTokens = testService.createTestMember();
-        return ResponseEntity.ok(testTokens);
+        return new SuccessResponse<>(testTokens);
     }
 }

--- a/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.domain.member.application;
 
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_MEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -11,6 +12,7 @@ import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import com.gobongbob.festamate.serviceSliceTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -150,7 +152,7 @@ class MemberServiceTest extends serviceSliceTest {
 
             // then
             Member updatedMember = memberRepository.findById(member.getId())
-                    .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                    .orElseThrow(() -> new BadRequestException(NO_MEMBER));
 
             assertAll(
                     () -> assertThat(updatedMember.getNickname()).isEqualTo(nicknameToUpdate),
@@ -174,7 +176,7 @@ class MemberServiceTest extends serviceSliceTest {
 
             // then
             assertThatThrownBy(() -> memberRepository.findById(member.getId())
-                    .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다.")))
+                    .orElseThrow(() -> new BadRequestException(NO_MEMBER)))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("사용자가 존재하지 않습니다.");
         }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#89 

### 📝 작업 내용
Sentry에서 예상된 예외 처리에 대한 에러도 issue로 인식하는 상황이 발생했습니다. (Ex: 이미 모임방에 참여했습니다!)
Sentry를 도입한 목적은 예상치 못한 에러가 터졌을 경우 빠르게 대처하기 위한 것이기 때문에, 전역 예외 처리 핸들러를 구현하여 예상치 못한 에러에 대한 알림만 받도록 수정합니다.

### 📷 변경 내용 

**기본적인 응답** 
isSuccess와 message가 추가됐습니다.

- 변경 전
![image](https://github.com/user-attachments/assets/459e903e-62c7-40a7-85ce-8d832f8fabf2)


- 변경 후
![image](https://github.com/user-attachments/assets/d46367fc-8414-4e1f-bd2c-70794f3b697d)

**에러 응답**
방 생성할 때 제목의 글자 수 제한을 넘을 때
- 변경 전
클라이언트로 응답 없이 서버 내에서 에러를 내뱉습니다.

- 변경 후
클라이언트에게 에러의 내용을 전달하고, 서버 내에서도 로그로 에러를 내뱉습니다.
![image](https://github.com/user-attachments/assets/0258bcb5-0a64-4d4d-ba99-013c28b559ed)


### 💬 리뷰 요구사항 (선택)
소셜 로그인 관련(Ex: 토큰, 로그인 등등) 예외 처리는 바로 에러를 내뱉도록 해놨습니다. 다들 어떻게 생각하시나요?? 이 부분도 공통 예외 처리를 해줄까요?