### PR TITLE
FK로 인한 엔티티 삭제 불가 문제 해결

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
@@ -22,8 +22,9 @@ public class CustomMemberDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         //UserDetails에 담아서 return하면 AutneticationManager가 검증 함
-        Member member = memberRepository.findByLoginIdWithProfileImage(loginId)
+        Member member = memberRepository.findByIdWithProfileImage(Long.parseLong(loginId))
                 .orElseThrow(() -> new BadRequestException(USER_NOT_FOUND));
+
         return new CustomMemberDetails(member);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
@@ -1,6 +1,8 @@
 package com.gobongbob.festamate.domain.auth.jwt.application;
 
 
+import static com.gobongbob.festamate.global.response.ResponseCode.USER_NOT_FOUND;
+
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
@@ -11,8 +13,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import static com.gobongbob.festamate.global.response.ResponseCode.USER_NOT_FOUND;
-
 @Service
 @RequiredArgsConstructor
 public class CustomMemberDetailsService implements UserDetailsService {
@@ -22,7 +22,7 @@ public class CustomMemberDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         //UserDetails에 담아서 return하면 AutneticationManager가 검증 함
-        Member member = memberRepository.findByLoginId(loginId)
+        Member member = memberRepository.findByLoginIdWithProfileImage(loginId)
                 .orElseThrow(() -> new BadRequestException(USER_NOT_FOUND));
 
         return new CustomMemberDetails(member);

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomRepository.java
@@ -1,8 +1,19 @@
 package com.gobongbob.festamate.domain.chat.persistence;
 
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+import com.gobongbob.festamate.domain.room.domain.Room;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
+    Optional<ChatRoom> findByRoom(Room room);
+
+    @Transactional
+    @Modifying
+    @Query("delete from ChatRoom c where c.room.id = ?1")
+    void deleteByRoomId(Long id);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/MessageRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/MessageRepository.java
@@ -4,10 +4,17 @@ import com.gobongbob.festamate.domain.chat.domain.Message;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
     @Query("select m from Message m where m.chatRoom.room.id = ?1")
     Slice<Message> findByRoomId(Long id, Pageable pageable);
+
+    @Transactional
+    @Modifying
+    @Query("delete from Message m where m.chatRoom.room.id = ?1")
+    void deleteByRoomId(Long id);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -25,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final String DEFAULT_PROFILE_IMAGE_NAME = "default_profile_image.png";
+
     private final MemberRepository memberRepository;
     private final ProfileImageRepository profileImageRepository;
     private final TokyoSnsService tokyoSnsService;
@@ -32,14 +34,14 @@ public class MemberService {
     @Transactional
     public Member createMember(MemberCreateRequest request) {
         Member member = request.toEntity();
-        profileImageRepository.findByStoreName("default_profile_image.png")
+        profileImageRepository.findByStoreName(DEFAULT_PROFILE_IMAGE_NAME)
                 .ifPresent(member::initializeProfileImage);
 
         return memberRepository.save(member);
     }
 
     public List<MemberResponse> findAllMembers() {
-        return memberRepository.findAll()
+        return memberRepository.findAllWithProfileImage()
                 .stream()
                 .map(MemberResponse::fromEntity)
                 .toList();
@@ -47,7 +49,7 @@ public class MemberService {
 
     // 유저 조회
     public MemberResponse findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdWithProfileImage(memberId)
                 .map(MemberResponse::fromEntity)
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
@@ -60,13 +62,13 @@ public class MemberService {
             throw new IllegalArgumentException("관리자 권한이 필요합니다.");
         }
 
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdWithProfileImage(memberId)
                 .map(MemberResponse::fromEntity)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
 
     public Member findMembersById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdWithProfileImage(memberId)
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
 
@@ -151,7 +153,7 @@ public class MemberService {
 
     // 아래부터는 oauth2를 위한 메서드
     public Member findById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdWithProfileImage(memberId)
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -149,7 +149,7 @@ public class Member {
     }
 
     public boolean isHost(Room room) {
-        return "ADMIN".equals(this.role) || room.getHost().equals(this);
+        return "ADMIN".equals(this.role) || room.getHost().getId().equals(this.getId());
     }
 
     /***

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberProfileResponse.java
@@ -17,15 +17,7 @@ public record MemberProfileResponse(
 ) {
 
     public static MemberProfileResponse fromEntity(Member member) {
-        // null-safe 하게 profileImage 가져오기
-        Image profileImage = null;
-        if (member.getProfileImage() != null) {
-            profileImage = member.getProfileImage().getImage();
-        }
-
-        // null이면 null을 넘기고, 있으면 fromEntity로 넘기기
-        ImageResponse imageResponse =
-                profileImage != null ? ImageResponse.fromEntity(profileImage) : null;
+        Image profileImage = member.getProfileImage().getImage();
 
         return new MemberProfileResponse(
                 member.getName(),
@@ -36,7 +28,7 @@ public record MemberProfileResponse(
                 member.getMajor() != null ? member.getMajor().getDepartment() : "Unknown",
                 member.getMaximumTicket(),
                 member.getRemainingTicket(),
-                imageResponse
+                ImageResponse.fromEntity(profileImage)
         );
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/persistence/MemberRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/persistence/MemberRepository.java
@@ -4,6 +4,7 @@ import com.gobongbob.festamate.domain.auth.oauth.domain.OauthInfo;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
@@ -12,7 +13,13 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     List<Member> findAll();
 
+    @Query("SELECT m FROM Member m JOIN FETCH m.profileImage")
+    List<Member> findAllWithProfileImage();
+
     Optional<Member> findById(Long id);
+
+    @Query("SELECT m FROM Member m JOIN FETCH m.profileImage WHERE m.id = :id")
+    Optional<Member> findByIdWithProfileImage(Long id);
 
     void delete(Member room);
 
@@ -20,7 +27,8 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     boolean existsByNickname(String nickname); // 닉네임 중복 확인
 
-    Optional<Member> findByLoginId(String loginId);
+    @Query("SELECT m FROM Member m JOIN FETCH m.profileImage WHERE m.loginId = ?1")
+    Optional<Member> findByLoginIdWithProfileImage(String loginId);
 
     Optional<Member> findByPhoneNumber(String phoneNumber); // 전화번호로 회원 조회
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -7,6 +7,7 @@ import static com.gobongbob.festamate.global.response.ResponseCode.NOT_FOUND_ROO
 
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
+import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.image.domain.RoomImage;
 import com.gobongbob.festamate.domain.image.infrastructure.ImageService;
 import com.gobongbob.festamate.domain.member.domain.Gender;
@@ -38,6 +39,7 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final RoomParticipantRepository roomParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
     private final ImageService imageService;
 
     @Transactional
@@ -114,11 +116,13 @@ public class RoomService {
     // 방 삭제(일반, admin)
     @Transactional
     public void deleteRoomById(Member member, Long roomId) {
-        Room room = roomRepository.findById(roomId)
+        Room room = roomRepository.findByIdWithHost(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
 
-        roomParticipantRepository.deleteByRoom(room);
+        roomParticipantRepository.deleteByRoomId(roomId);
+        messageRepository.deleteByRoomId(roomId);
+        chatRoomRepository.deleteByRoomId(roomId);
         roomRepository.delete(room);
 
         /*

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -98,7 +98,7 @@ public class RoomService {
 
     @Transactional
     public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request) {
-        Room room = roomRepository.findById(roomId)
+        Room room = roomRepository.findByIdWithHost(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
         validateAlone(room);

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
@@ -4,6 +4,7 @@ import com.gobongbob.festamate.domain.room.domain.Room;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface RoomRepository extends Repository<Room, Long> {
@@ -13,6 +14,9 @@ public interface RoomRepository extends Repository<Room, Long> {
     Page<Room> findAll(Pageable pageable);
 
     Optional<Room> findById(Long id);
+
+    @Query("SELECT r FROM Room r JOIN FETCH r.host WHERE r.id = :id")
+    Optional<Room> findByIdWithHost(Long id);
 
     void delete(Room room);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomParticipantRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomParticipantRepository.java
@@ -1,12 +1,13 @@
 package com.gobongbob.festamate.domain.room.presentation;
 
 import com.gobongbob.festamate.domain.room.domain.Role;
-import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
 
@@ -20,7 +21,10 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
 
     void deleteByMember_Id(Long memberId);
 
-    void deleteByRoom(Room room);
+    @Transactional
+    @Modifying
+    @Query("delete from RoomParticipant r where r.room.id = ?1")
+    void deleteByRoomId(Long id);
 
     List<RoomParticipant> findByRoom_Id(Long roomId);
 

--- a/src/main/java/com/gobongbob/festamate/testUser/TestService.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestService.java
@@ -29,6 +29,10 @@ public class TestService {
         Member testMember = createTestMemberEntity("Test User7", "test_nickname7",
                 "test_student_id7");
 
+        // 초기 프로필 이미지 설정
+        profileImageRepository.findByStoreName("default_profile_image.png")
+                .ifPresent(testMember::initializeProfileImage);
+
         // DB에 회원 저장
         memberRepository.save(testMember);  // JPA를 사용하여 DB에 저장
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#114 

### 📝 작업 내용
- `모임방` 삭제 시, 그에 따른 `모임방 참여자`, `채팅방`, `채팅`이 모두 삭제되도록 서비스 로직을 추가했습니다.
- 회원의 프로필 이미지가 Lazy Loading 설정으로 인해 일반적인 findById() 메서드로는 조회가 불가한 문제가 있었습니다.
  - 이를 해결하기 위해 Fetch Join을 사용한 메서드를 추가 작성하여 로직을 수정했습니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
모임방 매칭 완료, 삭제 정책에 대해 좀 더 고민해봐야 할 것 같습니다.
`모임`이 완료됐다고 해서 `모임방`, `참가자 정보`, `채팅 기록` 등을 모두 삭제해버리면 사용자 입장에서 불편할 것 같아요.

지금으로서 생각이 드는 건, 모임방에 ENUM 형태의 필드를 통해 `매칭중` / `매칭 완료` 상태를 표시하고,
매칭 완료가 되면 모임방에 대한 참여나 채팅 입력을 모두 막을 수 있을 것 같습니다.
-> 만약 이렇게 되면 홈 화면의 모임 조회는 `매칭중`인 모임방만 조회하도록 바꿔야됩니다.

아무튼 모임방 완전 삭제는 좀 부작용이 좀 클 것 같고, 위처럼 상태를 조작하거나 삭제해도 SOFT DELETE로 가야하지 않을까 싶네요.