### PR TITLE
loadUserByUsername에서 loginId를 사용하도록 변경

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/application/CustomMemberDetailsService.java
@@ -20,11 +20,9 @@ public class CustomMemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        // id로 Member를 찾고, 없으면 예외 처리
-        Member member = memberRepository.findById(Long.valueOf(id))
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new BadRequestException(USER_NOT_FOUND));
-
         return new CustomMemberDetails(member);
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#110 

### 📝 작업 내용
사용자 조회 시 loadUserByUsername에서 id가 아닌 loginId로 조회하도록 수정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

