### PR TITLE
카카오 소셜로그인 및 프로필 연동 로직 안정화

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/application/OauthService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/application/OauthService.java
@@ -1,13 +1,13 @@
 package com.gobongbob.festamate.domain.auth.oauth.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gobongbob.festamate.domain.auth.jwt.application.TokenService;
 import com.gobongbob.festamate.domain.auth.jwt.domain.TokenType;
 import com.gobongbob.festamate.domain.auth.oauth.dto.request.KakaoUserInfo;
 import com.gobongbob.festamate.domain.auth.oauth.dto.response.KakaoCheckResponse;
 import com.gobongbob.festamate.domain.auth.oauth.dto.response.KakaoTokenResponse;
+import com.gobongbob.festamate.domain.image.persistence.ProfileImageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.dto.request.ProfileRegisterRequest;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
@@ -23,6 +23,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 // 소그인 핵심 로직
 // 인가 코드를 받아서 액세스 토큰을 요청하고, 사용자 정보를 가져오는 서비스로 카카오 로그인 페이지로 리다이렉션 됨.
@@ -33,8 +34,10 @@ public class OauthService {
 
     private final WebClient webClient;
     private final MemberRepository memberRepository;
-    private final ObjectMapper objectMapper;
     private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
+    private final ProfileImageRepository profileImageRepository;
+    private static final String DEFAULT_PROFILE_IMAGE_NAME = "default_profile_image.png";
 
     @Value("${kakao.client-id}")
     private String clientId;
@@ -54,10 +57,10 @@ public class OauthService {
      */
     public KakaoCheckResponse checkKakaoUser(String code) {
         // 1. 카카오 인가 코드를 통해 access token 발급
-        String kakaoAccessToken = getKakaoAccessToken(code).toString();
+        String kakaoAccessToken = getKakaoAccessToken(code).get("accessToken");
 
-        // 2. access token으로 사용자 정보 요청
-        KakaoUserInfo userInfo = (KakaoUserInfo) getKakaoUserInfo(kakaoAccessToken);
+        // 2. access token으로 사용자 정보 요청 (KakaoUserInfo 객체 반환)
+        KakaoUserInfo userInfo = getKakaoUserInfo(kakaoAccessToken); // 캐스팅 제거
 
         // 3. DB에 해당 kakaoId가 존재하는지 여부 확인
         boolean isMember = memberRepository.existsByKakaoId(userInfo.getId());
@@ -66,22 +69,28 @@ public class OauthService {
     }
 
     /**
-     * 기존 회원 로그인 시, Kakao Access Token으로 kakaoId 추출 후 JWT 반환
+     * 기존 회원 로그인 시, Kakao Access Token으로 kakaoId 추출 후 사용자 ID 반환
      */
     public Long findUserIdByKakaoToken(String kakaoAccessToken) {
-        KakaoUserInfo userInfo = (KakaoUserInfo) getKakaoUserInfo(kakaoAccessToken);
+        KakaoUserInfo userInfo = getKakaoUserInfo(kakaoAccessToken); // 캐스팅 제거
         Member member = memberRepository.findByKakaoId(userInfo.getId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(() -> {
+                    return new IllegalArgumentException("존재하지 않는 회원입니다.");
+                });
         return member.getId();
     }
 
+    /**
+     * 카카오 정보 기반 로그인 처리 및 JWT 발급
+     */
     public Map<String, String> loginWithKakao(String kakaoAccessToken) {
-        // 카카오 액세스 토큰을 통해 유저 ID를 가져옴
-        Long userId = findUserIdByKakaoToken(kakaoAccessToken);
+        Long userId = findUserIdByKakaoToken(kakaoAccessToken); // 사용자 ID 조회
 
         // 유저 정보 가져오기
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> { // findUserIdByKakaoToken 에서 이미 확인했지만, 방어적으로 추가
+                    return new IllegalArgumentException("유저를 찾을 수 없습니다.");
+                });
 
         // 프로필 완료 여부 확인
         if (member.isProfileCompleted()) {
@@ -94,12 +103,11 @@ public class OauthService {
     }
 
     /**
-     * 신규 회원 프로필 등록: Kakao ID 기반 회원 생성
+     * 신규 회원 프로필 등록: Kakao ID 기반 회원 생성 및 프로필 정보 저장
      */
     @Transactional
     public Long registerNewMember(ProfileRegisterRequest request) {
-        KakaoUserInfo userInfo = (KakaoUserInfo) getKakaoUserInfo(
-                request.kakaoAccessToken()); // record의 필드 사용
+        KakaoUserInfo userInfo = getKakaoUserInfo(request.kakaoAccessToken()); // 캐스팅 제거
 
         if (memberRepository.existsByKakaoId(userInfo.getId())) {
             throw new IllegalStateException("이미 존재하는 회원입니다.");
@@ -113,14 +121,21 @@ public class OauthService {
         // 요청에서 받은 데이터를 Member 객체에 세팅
         request.toEntity(newMember);  // nickname은 랜덤 생성
 
-        // 프로필 등록이 완료되었음을 표시
-        newMember.completeProfile(); // 프로필 완료 처리
+        // DB에서 기본 프로필 이미지 조회하여 기본 이미지 설정
+        profileImageRepository.findByStoreName(DEFAULT_PROFILE_IMAGE_NAME) // 상수를 사용하여 조회
+                .ifPresent(defaultImage -> {
+                    // 테스트 코드에서 확인된 initializeProfileImage 메서드 사용
+                    newMember.initializeProfileImage(defaultImage);
+                    System.out.println("✅ 기본 프로필 이미지 설정됨 ✅: " + defaultImage.getId());
+                });
 
-        // RDS에 저장
-        memberRepository.save(newMember);  // 이 부분 추가!
+        // 프로필 등록 완료 처리
+        newMember.completeProfile();
 
-        // 성공적으로 저장된 Member의 ID 반환
-        return newMember.getId();
+        // DB에 저장
+        Member savedMember = memberRepository.save(newMember);
+
+        return savedMember.getId();
     }
 
     // 🔹 카카오 인가 코드로 Access Token 발급
@@ -133,35 +148,69 @@ public class OauthService {
 
         KakaoTokenResponse response = webClient.post()
                 .uri(tokenUri)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE
+                        + ";charset=utf-8") // charset 추가
                 .body(BodyInserters.fromFormData(body))
                 .retrieve()
+                // 응답 상태 코드 에러 처리 (4xx, 5xx)
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    System.err.println(
+                                            "❌ 카카오 토큰 발급 API 오류: " + clientResponse.statusCode()
+                                                    + ", 응답: " + errorBody);
+                                    return Mono.error(
+                                            new RuntimeException("카카오 토큰 발급 실패: " + errorBody));
+                                }))
                 .bodyToMono(KakaoTokenResponse.class)
-                .block();
+                .block(); // 동기 처리
 
-        // Map으로 변환하여 access_token만 넣어 반환
+        // Null 체크 및 토큰 추출
+        if (response == null || response.getAccessToken() == null) {
+            throw new RuntimeException("카카오 액세스 토큰을 가져오는데 실패했습니다.");
+        }
+
         Map<String, String> tokens = new HashMap<>();
         tokens.put("accessToken", response.getAccessToken());
-
         return tokens;
     }
 
-    // 🔹 Kakao Access Token으로 사용자 정보 조회
-    private Map<String, String> getKakaoUserInfo(String accessToken) {
+    // 🔹 Kakao Access Token으로 사용자 정보 조회 (반환 타입을 KakaoUserInfo로 변경)
+    private KakaoUserInfo getKakaoUserInfo(String accessToken) {
         String json = webClient.get()
                 .uri(userInfoUri)
-                .header("Authorization", "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .retrieve()
+                // 응답 상태 코드 에러 처리 (4xx, 5xx)
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    System.err.println(
+                                            "❌ 카카오 사용자 정보 API 오류: " + clientResponse.statusCode()
+                                                    + ", 응답: " + errorBody);
+                                    // 401 Unauthorized 경우 토큰 만료 가능성 있음
+                                    if (clientResponse.statusCode().value() == 401) {
+                                        return Mono.error(
+                                                new RuntimeException("카카오 토큰이 만료되었거나 유효하지 않습니다."));
+                                    }
+                                    return Mono.error(
+                                            new RuntimeException("카카오 사용자 정보 조회 실패: " + errorBody));
+                                }))
                 .bodyToMono(String.class)
-                .block();
+                .block(); // 동기 처리
+
+        if (json == null) {
+            throw new RuntimeException("카카오 사용자 정보 응답이 비어있습니다.");
+        }
 
         try {
-            JsonNode root = objectMapper.readTree(json);
-            Long kakaoId = root.get("id").asLong();
+            // ObjectMapper를 사용하여 JSON 문자열을 KakaoUserInfo DTO 객체로 변환
+            KakaoUserInfo userInfo = objectMapper.readValue(json, KakaoUserInfo.class);
 
-            // Map으로 반환
-            Map<String, String> userInfo = new HashMap<>();
-            userInfo.put("kakaoId", String.valueOf(kakaoId)); // kakaoId는 String으로 반환
+            // 필수 정보인 ID가 파싱되었는지 확인
+            if (userInfo == null || userInfo.getId() == null) {
+                throw new RuntimeException("카카오 사용자 정보 파싱 실패: 사용자 ID를 찾을 수 없습니다.");
+            }
 
             return userInfo;
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/dto/request/KakaoUserInfo.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/dto/request/KakaoUserInfo.java
@@ -1,11 +1,13 @@
 package com.gobongbob.festamate.domain.auth.oauth.dto.request;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor // Jackson 역직렬화를 위해 필수
+@JsonIgnoreProperties(ignoreUnknown = true) // 정의되지 않은 다른 JSON 필드 무시)
 public class KakaoUserInfo {
 
-    private Long id;
+    private Long id; // 필요한 사용자 고유 ID 필드만 정의
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/dto/response/KakaoTokenResponse.java
@@ -4,10 +4,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+// 카카오 API가 제공하는 전체 응답 데이터를 DTO에 반영
 @Getter
 @Setter
 public class KakaoTokenResponse {
 
     @JsonProperty("access_token")
     private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
 }

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -9,6 +9,7 @@ import com.gobongbob.festamate.domain.auth.oauth.dto.response.KakaoCheckResponse
 import com.gobongbob.festamate.domain.member.application.MemberService;
 import com.gobongbob.festamate.domain.member.dto.request.ProfileRegisterRequest;
 import com.gobongbob.festamate.global.response.SuccessResponse;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -49,11 +50,13 @@ public class OauthController {
 
     // 3️⃣ 신규 회원 프로필 등록 후 JWT 발급
     @PostMapping("/register/profile")
+    @Transactional // 이 메서드 전체를 하나의 트랜잭션으로 묶음
     public SuccessResponse<Map<String, String>> registerProfile(
             @RequestBody ProfileRegisterRequest request) {
 
-        Long userId = oauthService.registerNewMember(request);
-        Map<String, String> tokens = tokenService.generateTokens(userId, TokenType.FINAL_ACCESS);
+        Long userId = oauthService.registerNewMember(request); // 같은 트랜잭션 내에서 실행
+        Map<String, String> tokens = tokenService.generateTokens(userId,
+                TokenType.FINAL_ACCESS); // 같은 트랜잭션 내에서 실행
         return new SuccessResponse<>(tokens);
-    }
+    } // 메서드 종료 시 트랜잭션 커밋
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -1,7 +1,9 @@
 package com.gobongbob.festamate.domain.member.application;
 
 import static com.gobongbob.festamate.global.response.ResponseCode.DUPLICATE_NICKNAME;
+import static com.gobongbob.festamate.global.response.ResponseCode.NO_ADMIN;
 import static com.gobongbob.festamate.global.response.ResponseCode.NO_MEMBER;
+import static com.gobongbob.festamate.global.response.ResponseCode.PHONE_NOT_VERIFIED;
 
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.image.persistence.ProfileImageRepository;
@@ -19,8 +21,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.gobongbob.festamate.domain.member.dto.request;
 
 public record ProfileUpdateRequest(
-        String nickname
-) {
+        String nickname,
+        String loginPasswordToUpdate) {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    # /home/ubuntu/ 경로에 있는 .env 파일을 선택적으로 임포트
+    import: "optional:file:/home/ubuntu/.env[.properties]"
   jackson:
     time-zone: Asia/Seoul
   datasource:
@@ -41,9 +44,8 @@ spring:
         access-key: ${AWS_SNS_ACCESS_KEY}
         secret-key: ${AWS_SNS_SECRET_KEY}
       region:
-        static: ap-northeast-1 # 도쿄 리전
+        static: ap-northeast-1 # 도쿄 리전 (SNS 관련)
 jwt:
-  header: Authorization
   secret: ${JWT_SECRET}
 naver:
   ocr:
@@ -56,8 +58,13 @@ sentry:
   max-request-body-size: small
 server:
   forward-headers-strategy: framework
+kakao: # 설정값들을 직접 참조 하기 위함
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: ${KAKAO_TOKEN_URI}
+  user-info-uri: ${KAKAO_USER_INFO_URI}
 
-# AWS S3
+# AWS S3 관련 설정
 cloud:
   aws:
     s3: ${S3_BUCKET_NAME}
@@ -65,6 +72,6 @@ cloud:
       access-key: ${IAM_USER_ACCESS_KEY}
       secret-key: ${IAM_USER_SECRET_KEY}
     region:
-      static: ap-northeast-2
+      static: ap-northeast-2 # 서울 리전 (S3 관련)
     stack:
       auto: false


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#131 

### 📝 작업 내용
카카오 통신 방식 개선: 토큰/사용자 정보 요청/응답 처리 방식 개선
회원가입 시 기본 프로필 사진 설정: 새 회원이 가입할 때 자동으로 기본 프로필 사진 사용
사용자 정보 로딩 방식 최적화: Spring Security가 사용자 정보를 불러올 때 발생하던 문제를 JPA 기능(JOIN FETCH)을 활용해 해결
데이터 변환 시 안정성 강화: 사용자 정보를 화면에 보여줄 형식(DTO)으로 바꿀 때 발생하던 오류를 방지

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
자세한 내용은 고봉밥 기술 레퍼런스에 작성할 예정입니다 ㅋㅋㅋ
아직 병합을 안 해서 배포 시에도 되는 지는 잘 모르겠어요.
