### PR TITLE
필터 설정에 따른 모임방 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 .env
 festamate-firebase-key.json
+generated/

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -87,4 +93,24 @@ tasks.named('test') {
 test {
     useJUnitPlatform()
     systemProperty 'spring.profiles.active', 'test'
+}
+
+
+// QueryDSL Build 옵션
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
+bootJar {
+    duplicatesStrategy = 'exclude'
 }

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Gender.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Gender.java
@@ -1,23 +1,20 @@
 package com.gobongbob.festamate.domain.member.domain;
 
-import java.util.Arrays;
-
-import com.gobongbob.festamate.global.response.exception.BadRequestException;
-import lombok.Getter;
-
 import static com.gobongbob.festamate.global.response.ResponseCode.NO_GENDER;
 
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 @Getter
+@AllArgsConstructor
 public enum Gender {
     MALE("남성"),
     FEMALE("여성"),
     ANY("무관");
 
     private final String name;
-
-    Gender(String name) {
-        this.name = name;
-    }
 
     public static Gender findByName(String name) {
         return Arrays.stream(Gender.values())

--- a/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/domain/Member.java
@@ -43,6 +43,7 @@ public class Member {
     private Long kakaoId; // 카카오 고유 ID로 기존 사용자와 구분하기 위해 사용
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean isProfileCompleted = false; // 첫 로그인 후 프로필 작성 여부 판단용
 
     public void completeProfile() {

--- a/src/main/java/com/gobongbob/festamate/domain/report/domain/ReportReason.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/domain/ReportReason.java
@@ -1,9 +1,13 @@
 package com.gobongbob.festamate.domain.report.domain;
 
-import com.gobongbob.festamate.global.response.exception.BadRequestException;
-
 import static com.gobongbob.festamate.global.response.ResponseCode.NO_REPORT_REASON;
 
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ReportReason {
     UNHEALTHY("음란물/불건전한 만남 및 대화"),
     ABUSE("욕설/비하"),
@@ -14,10 +18,6 @@ public enum ReportReason {
     ILLEGAL("불법촬영물 등의 유통");
 
     private final String name;
-
-    ReportReason(String name) {
-        this.name = name;
-    }
 
     public static ReportReason findByName(String name) {
         for (ReportReason reason : ReportReason.values()) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -17,6 +17,7 @@ import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
+import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
@@ -25,8 +26,8 @@ import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -70,8 +71,8 @@ public class RoomService {
         return chatRoom;
     }
 
-    public Page<RoomListResponse> findAllRooms(Pageable pageable) {
-        return roomRepository.findAll(pageable)
+    public Slice<RoomListResponse> findBySearchCondition(Pageable pageable, SearchCondition searchCondition) {
+        return roomRepository.findBySearchCondition(pageable, searchCondition)
                 .map(room -> RoomListResponse.fromEntity(
                         room,
                         roomParticipantRepository.countByRoom_Id(room.getId())

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Role.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Role.java
@@ -4,20 +4,16 @@ import static com.gobongbob.festamate.global.response.ResponseCode.ROLE_NOT_FOUN
 
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
+@AllArgsConstructor
 public enum Role {
     HOST("HOST"),
     GUEST("GUEST");
 
     private final String name;
-
-    Role(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
 
     public static Role findByName(String name) {
         return Arrays.stream(Role.values())

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -5,6 +5,8 @@ import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -37,6 +39,10 @@ public class Room {
     private String place;
 
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private Status status = Status.MATCHING;
 
     private int maxParticipants;
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -44,12 +44,12 @@ public class Room {
 
     private LocalDateTime meetingDateTime;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_id")
     private Member host;
 
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<RoomImage> images = new ArrayList<>();
 
     // 연관관계 편의 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -46,6 +46,7 @@ public class Room {
 
     private int maxParticipants;
 
+    @Enumerated(EnumType.STRING)
     private Gender preferredGender;
 
     private LocalDateTime meetingDateTime;

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Status.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Status.java
@@ -1,6 +1,6 @@
 package com.gobongbob.festamate.domain.room.domain;
 
-import static com.gobongbob.festamate.global.response.ResponseCode.ROLE_NOT_FOUND;
+import static com.gobongbob.festamate.global.response.ResponseCode.STATUS_NOT_FOUND;
 
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import java.util.Arrays;
@@ -16,10 +16,10 @@ public enum Status {
 
     private final String name;
 
-    public static Role findByName(String name) {
-        return Arrays.stream(Role.values())
-                .filter(role -> role.getName().equals(name))
+    public static Status findByName(String name) {
+        return Arrays.stream(Status.values())
+                .filter(status -> status.getName().equals(name))
                 .findFirst()
-                .orElseThrow(() -> new BadRequestException(ROLE_NOT_FOUND));
+                .orElseThrow(() -> new BadRequestException(STATUS_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Status.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Status.java
@@ -1,0 +1,25 @@
+package com.gobongbob.festamate.domain.room.domain;
+
+import static com.gobongbob.festamate.global.response.ResponseCode.ROLE_NOT_FOUND;
+
+import com.gobongbob.festamate.global.response.exception.BadRequestException;
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Status {
+    MATCHING("매칭중"),
+    MATCHED("매칭 완료"),
+    CLOSED("모임 종료");
+
+    private final String name;
+
+    public static Role findByName(String name) {
+        return Arrays.stream(Role.values())
+                .filter(role -> role.getName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(ROLE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
@@ -1,11 +1,16 @@
 package com.gobongbob.festamate.domain.room.dto.request;
 
+import com.gobongbob.festamate.domain.member.domain.Gender;
+import com.gobongbob.festamate.domain.room.domain.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record SearchCondition(
-        String status,
-        int participants,
-        String studentId,
-        String gender,
-        String sortType
+        @Schema(description = "매칭 상태", enumAsRef = true)
+        Status status,
+        @Schema(description = "입장 가능 성별", enumAsRef = true)
+        Gender gender,
+        Integer participants,
+        String studentId
 ) {
 
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
@@ -1,0 +1,11 @@
+package com.gobongbob.festamate.domain.room.dto.request;
+
+public record SearchCondition(
+        String status,
+        int participants,
+        String studentId,
+        String gender,
+        String sortType
+) {
+
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.domain.room.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
 import com.gobongbob.festamate.domain.room.domain.Room;
@@ -11,6 +12,7 @@ public record RoomListResponse(
         String place,
         String content,
         String preferredGender,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
         int currentParticipants,

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.domain.room.domain.Status;
 import java.time.LocalDateTime;
 
 public record RoomListResponse(
         Long id,
         String title,
+        Status status,
         String place,
         String content,
         String preferredGender,
@@ -25,6 +27,7 @@ public record RoomListResponse(
         return new RoomListResponse(
                 room.getId(),
                 room.getTitle(),
+                room.getStatus(),
                 room.getPlace(),
                 room.getContent(),
                 room.getPreferredGender().getName(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
+import com.gobongbob.festamate.domain.room.domain.Status;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record RoomResponse(
         Long id,
         String title,
+        Status status,
         String place,
         String content,
         String preferredGender,
@@ -29,6 +31,7 @@ public record RoomResponse(
         return new RoomResponse(
                 room.getId(),
                 room.getTitle(),
+                room.getStatus(),
                 room.getPlace(),
                 room.getContent(),
                 room.getPreferredGender().getName(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.domain.room.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
@@ -12,6 +13,7 @@ public record RoomResponse(
         String place,
         String content,
         String preferredGender,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
         List<ParticipantResponse> hostParticipants,

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
@@ -1,0 +1,11 @@
+package com.gobongbob.festamate.domain.room.persistence;
+
+import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface RoomQueryDslRepository {
+
+    Slice<Room> findByFilter(SearchCondition searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Slice;
 
 public interface RoomQueryDslRepository {
 
-    Slice<Room> findByFilter(SearchCondition searchCondition, Pageable pageable);
+    Slice<Room> findBySearchCondition(SearchCondition searchCondition, Pageable pageable);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Slice;
 
 public interface RoomQueryDslRepository {
 
-    Slice<Room> findBySearchCondition(SearchCondition searchCondition, Pageable pageable);
+    Slice<Room> findBySearchCondition(Pageable pageable, SearchCondition searchCondition);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.gobongbob.festamate.domain.room.persistence;
 
 import static com.gobongbob.festamate.domain.room.domain.QRoom.room;
-import static com.gobongbob.festamate.domain.room.domain.QRoomParticipant.roomParticipant;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.gobongbob.festamate.domain.member.domain.Gender;
@@ -9,10 +8,8 @@ import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.Status;
 import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -37,14 +34,14 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
                 .selectFrom(room)
                 .where(
                         statusEquals(searchCondition.status()),
-                        participantsEquals(searchCondition.participants()),
-                        studentIdContains(searchCondition.studentId()),
-                        genderEquals(searchCondition.gender())
+                        genderEquals(searchCondition.gender()),
+                        participantsEquals(searchCondition.participants())
+//                                ,studentIdContains(searchCondition.studentId())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageSize + 1);
 
-        List<Room> content = addSortingQuery(basicQuery, searchCondition.sortType());
+        List<Room> content = addSortingQuery(basicQuery, pageable.getSort().toString());
 
         return new SliceImpl<>(content, pageable, hasNextPage(content, pageSize));
     }
@@ -62,31 +59,40 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
         return hasNext;
     }
 
-    private BooleanExpression participantsEquals(int participants) {
-        return hasText(String.valueOf(participants)) ? room.maxParticipants.eq(participants) : null;
+    private BooleanExpression statusEquals(Status status) {
+        if (status != null && hasText(status.getName())) {
+            return room.status.eq(status);
+        }
+
+        return null;
+    }
+
+    private BooleanExpression participantsEquals(Integer participants) {
+        if (participants != null) {
+            return room.maxParticipants.eq(participants);
+        }
+
+        return null;
+    }
+
+    private BooleanExpression genderEquals(Gender gender) {
+        if (gender != null && hasText(gender.getName())) {
+            return room.preferredGender.eq(gender);
+        }
+
+        return null;
     }
 
     // 방 안에 입력받은 학번을 가진 사람이 있는지 확인
-    private BooleanExpression studentIdContains(String studentId) {
-        JPQLQuery<Long> roomIdsOfStudentIdMatched = queryFactory
-                .select(roomParticipant.room.id)
-                .from(roomParticipant)
-                .where(roomParticipant.member.studentId.startsWith(studentId));
-
-        return room.id.in(roomIdsOfStudentIdMatched);
-    }
-
-    private BooleanExpression genderEquals(String gender) {
-        return hasText(gender) ? room.preferredGender.eq(Gender.valueOf(gender)) : null;
-    }
-
-    private BooleanExpression statusEquals(String status) {
-        if (!hasText(status)) {
-            return null;
-        }
-
-        return room.status.eq(Status.valueOf(status));
-    }
+    // Room 엔티티에 선호 학번이 들어가야 구현 가능하므로, 추후 구현할 예정
+//    private BooleanExpression studentIdContains(String studentId) {
+//        JPQLQuery<Long> roomIdsOfStudentIdMatched = queryFactory
+//                .select(roomParticipant.room.id)
+//                .from(roomParticipant)
+//                .where(roomParticipant.member.studentId.startsWith(studentId));
+//
+//        return room.id.in(roomIdsOfStudentIdMatched);
+//    }
 
     /*
       정렬 관련 쿼리를 추가하기 위한 메소드

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -30,7 +30,7 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
      * 모임 상태, 학과, 학번, 성별에 따른 조회
      */
     @Override
-    public Slice<Room> findBySearchCondition(SearchCondition searchCondition, Pageable pageable) {
+    public Slice<Room> findBySearchCondition(Pageable pageable, SearchCondition searchCondition) {
         int pageSize = pageable.getPageSize();
 
         JPAQuery<Room> basicQuery = queryFactory

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -1,0 +1,126 @@
+package com.gobongbob.festamate.domain.room.persistence;
+
+import static com.gobongbob.festamate.domain.room.domain.QRoom.room;
+import static com.gobongbob.festamate.domain.room.domain.QRoomParticipant.roomParticipant;
+import static org.springframework.util.StringUtils.hasText;
+
+import com.gobongbob.festamate.domain.member.domain.Gender;
+import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.domain.room.domain.Status;
+import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 모임 상태, 학과, 학번, 성별에 따른 조회
+     */
+    @Override
+    public Slice<Room> findByFilter(SearchCondition searchCondition, Pageable pageable) {
+        int pageSize = pageable.getPageSize();
+
+        JPAQuery<Room> basicQuery = queryFactory
+                .selectFrom(room)
+                .where(
+                        statusEquals(searchCondition.status()),
+                        participantsEquals(searchCondition.participants()),
+                        studentIdContains(searchCondition.studentId()),
+                        genderEquals(searchCondition.gender())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageSize + 1);
+
+        List<Room> content = addSortingQuery(basicQuery, searchCondition.sortType());
+
+        return new SliceImpl<>(content, pageable, hasNextPage(content, pageSize));
+    }
+
+    /**
+     * 마지막 페이지 여부 확인 메소드
+     */
+    private boolean hasNextPage(List<Room> content, int pageSize) {
+        boolean hasNext = false;
+        if (content.size() > pageSize) {
+            hasNext = true;
+            content.remove(pageSize);
+
+        }
+        return hasNext;
+    }
+
+    private BooleanExpression participantsEquals(int participants) {
+        return hasText(String.valueOf(participants)) ? room.maxParticipants.eq(participants) : null;
+    }
+
+    // 방 안에 입력받은 학번을 가진 사람이 있는지 확인
+    private BooleanExpression studentIdContains(String studentId) {
+        JPQLQuery<Long> roomIdsOfStudentIdMatched = queryFactory
+                .select(roomParticipant.room.id)
+                .from(roomParticipant)
+                .where(roomParticipant.member.studentId.startsWith(studentId));
+
+        return room.id.in(roomIdsOfStudentIdMatched);
+    }
+
+    private BooleanExpression genderEquals(String gender) {
+        return hasText(gender) ? room.preferredGender.eq(Gender.valueOf(gender)) : null;
+    }
+
+    private BooleanExpression statusEquals(String status) {
+        if (!hasText(status)) {
+            return null;
+        }
+
+        return room.status.eq(Status.valueOf(status));
+    }
+
+    /*
+      정렬 관련 쿼리를 추가하기 위한 메소드
+     */
+    private List<Room> addSortingQuery(JPAQuery<Room> basicQuery, String sortType) {
+        List<Room> content;
+
+        switch (sortType) {
+            case "id":
+                content = basicQuery
+                        .orderBy(room.id.desc())
+                        .fetch();
+                break;
+
+            case "rid":
+                content = basicQuery
+                        .orderBy(room.id.asc())
+                        .fetch();
+                break;
+
+            case "date":
+                content = basicQuery
+                        .orderBy(room.meetingDateTime.desc())
+                        .fetch();
+
+            case "rdate":
+                content = basicQuery
+                        .orderBy(room.meetingDateTime.asc())
+                        .fetch();
+
+            default:
+                content = new ArrayList<>();
+        }
+
+        return content;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -111,14 +111,19 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
                 content = basicQuery
                         .orderBy(room.meetingDateTime.desc())
                         .fetch();
+                break;
 
             case "rdate":
                 content = basicQuery
                         .orderBy(room.meetingDateTime.asc())
                         .fetch();
+                break;
 
             default:
-                content = new ArrayList<>();
+                content = basicQuery
+                        .orderBy(room.id.desc())
+                        .fetch(); // 기본 정렬
+                break;
         }
 
         return content;

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -30,7 +30,7 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
      * 모임 상태, 학과, 학번, 성별에 따른 조회
      */
     @Override
-    public Slice<Room> findByFilter(SearchCondition searchCondition, Pageable pageable) {
+    public Slice<Room> findBySearchCondition(SearchCondition searchCondition, Pageable pageable) {
         int pageSize = pageable.getPageSize();
 
         JPAQuery<Room> basicQuery = queryFactory

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
-public interface RoomRepository extends Repository<Room, Long> {
+public interface RoomRepository extends Repository<Room, Long>, RoomQueryDslRepository {
 
     Room save(Room room);
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -7,6 +7,7 @@ import com.gobongbob.festamate.domain.room.application.RoomParticipationService;
 import com.gobongbob.festamate.domain.room.application.RoomService;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
+import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.IsMemberHostResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
@@ -19,14 +20,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,16 +73,18 @@ public class RoomController {
         return new SuccessResponse<>();
     }
 
-    @Operation(summary = "모든 모임방 조회", description = "모든 방 목록을 페이징하여 조회합니다.")
+    @Operation(summary = "필터에 따른 모임방 조회", description = "필터에 따라 방 목록을 무한 스크롤 방식으로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.")
     })
     @GetMapping("")
-    public SuccessResponse<Page<RoomListResponse>> findAll(
+    public SuccessResponse<Slice<RoomListResponse>> findBySearchCondition(
             @Parameter(description = "페이징 정보")
-            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @Parameter(description = "필터링 조건")
+            @ModelAttribute SearchCondition searchCondition
     ) {
-        return new SuccessResponse<>(roomService.findAllRooms(pageable));
+        return new SuccessResponse<>(roomService.findBySearchCondition(pageable, searchCondition));
     }
 
     @Operation(summary = "참여 중인 모임방 조회", description = "사용자가 참여 중인 방 목록을 조회합니다.")

--- a/src/main/java/com/gobongbob/festamate/global/config/QueryDslConfig.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.gobongbob.festamate.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
     CAN_NOT_UPDATE(false, "방에 방장을 제외한 다른 사용자가 입장한 상태에서는 수정할 수 없습니다."),
     NOT_ENOUGH_TICKET(false, "티켓이 부족합니다."),
     ROLE_NOT_FOUND(false, "해당하는 권한이 없습니다."),
+    STATUS_NOT_FOUND(false, "해당하는 모임방 상태가 없습니다. (매칭중, 매칭완료, 종료)"),
 
     // 회원
     NO_MEMBER(false, "사용자가 존재하지 않습니다."),

--- a/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/member/application/MemberServiceTest.java
@@ -147,7 +147,7 @@ class MemberServiceTest extends serviceSliceTest {
             String loginPasswordToUpdate = "updatedLoginPassword";
 
             // when
-            ProfileUpdateRequest request = new ProfileUpdateRequest(nicknameToUpdate, loginPasswordToUpdate);
+            ProfileUpdateRequest request = new ProfileUpdateRequest(nicknameToUpdate);
             memberService.updateMemberProfileById(member, request);
 
             // then

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -125,7 +125,7 @@ class RoomServiceTest extends serviceSliceTest {
             Pageable pageable = PageRequest.of(0, 10);
 
             // when
-            Page<RoomListResponse> findRoomResponses = roomService.findAllRooms(pageable);
+            Page<RoomListResponse> findRoomResponses = roomService.findBySearchCondition(pageable);
 
             // then
             assertThat(findRoomResponses).hasSize(rooms.size());

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -16,8 +16,10 @@ import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import com.gobongbob.festamate.domain.room.domain.Room;
+import com.gobongbob.festamate.domain.room.domain.Status;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
+import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
@@ -31,9 +33,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -123,9 +125,16 @@ class RoomServiceTest extends serviceSliceTest {
             rooms.forEach(room -> testFixtureBuilder.buildRoom(room));
 
             Pageable pageable = PageRequest.of(0, 10);
+            SearchCondition searchCondition = new SearchCondition(
+                    Status.MATCHING.getName(),
+                    4,
+                    "20",
+                    Gender.MALE.getName(),
+                    "id"
+            );
 
             // when
-            Page<RoomListResponse> findRoomResponses = roomService.findBySearchCondition(pageable);
+            Slice<RoomListResponse> findRoomResponses = roomService.findBySearchCondition(pageable, searchCondition);
 
             // then
             assertThat(findRoomResponses).hasSize(rooms.size());

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -126,11 +126,10 @@ class RoomServiceTest extends serviceSliceTest {
 
             Pageable pageable = PageRequest.of(0, 10);
             SearchCondition searchCondition = new SearchCondition(
-                    Status.MATCHING.getName(),
+                    Status.MATCHING,
+                    Gender.MALE,
                     4,
-                    "20",
-                    Gender.MALE.getName(),
-                    "id"
+                    "20"
             );
 
             // when


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #132 

### 📝 작업 내용
- 필터 설정에 따른 모임방 조회 기능을 구현했습니다.
  - 필터 예시: `매칭 상태`, `성별`, `인원`, `학번`
  - 상세한 필터링 및 정렬을 위해서 QueryDsl을 활용, 조회 쿼리를 작성했습니다.
- Room 엔티티에 매칭 상태 관련 필드를 추가했으며, DTO 역시 수정했습니다.
- `일반 페이징` 대신 `무한 스크롤 페이징`을 적용했습니다.

### 📷 스크린샷 (선택)
- 요청 API URL 예시는 다음과 같습니다.
![스크린샷 2025-04-16 오후 8 14 42](https://github.com/user-attachments/assets/90385def-87c1-448f-9314-9cae8400aa16)

- JSON 응답은 다음과 같습니다.
```json
{
    "isSuccess": true,
    "message": "요청에 성공하였습니다.",
    "result": {
        "content": [
            {
                "id": 1,
                "title": "test title1",
                "place": "8강의동 흡연장",
                "content": "test content1",
                "preferredGender": "남성",
                "meetingDateTime": "2025-02-26 22:07:42",
                "maxParticipants": 4,
                "currentParticipants": 1,
                "thumbnail": {
                    "name": "fc370ebc-0f0d-4573-8087-9ffc3ea4f60e.jpeg",
                    "url": "https://festamate-bucket.s3.ap-northeast-2.amazonaws.com/fc370ebc-0f0d-4573-8087-9ffc3ea4f60e.jpeg"
                }
            }
        ],
        "pageable": {
            "pageNumber": 0,
            "pageSize": 10,
            "sort": {
                "empty": false,
                "sorted": true,
                "unsorted": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "first": true,
        "last": true,
        "size": 10,
        "number": 0,
        "sort": {
            "empty": false,
            "sorted": true,
            "unsorted": false
        },
        "numberOfElements": 1,
        "empty": false
    }
}
```

### 💬 리뷰 요구사항 (선택)
JSON 응답에서 개선하고 싶은 부분 있으면 알려주세요!
