### PR TITLE
모임방 생성 시의 학번 조건 설정

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/request/MemberCreateRequest.java
@@ -11,7 +11,7 @@ public record MemberCreateRequest(
         String loginId,
         String loginPassword,
         String phoneNumber,
-        String gender,
+        Gender gender,
         String college,
         String department
 ) {
@@ -24,7 +24,7 @@ public record MemberCreateRequest(
                 .loginId(loginId)
                 .loginPassword(loginPassword)
                 .phoneNumber(phoneNumber)
-                .gender(Gender.findByName(gender))
+                .gender(gender)
                 .major(Major.findByDepartment(department))
                 .build();
     }

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileRegisterRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/request/ProfileRegisterRequest.java
@@ -10,7 +10,7 @@ public record ProfileRegisterRequest(
         String studentId,
         String phoneNumber,
         String phoneVerificationCodes,
-        String gender,
+        Gender gender,
         String college,
         String department,
         String kakaoAccessToken, // 카카오 access token
@@ -24,7 +24,7 @@ public record ProfileRegisterRequest(
                 makeRandomNickname(),
                 studentId,
                 phoneNumber,
-                Gender.findByName(gender),
+                gender,
                 Major.findByDepartment(department)
         );
 

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberProfileResponse.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.member.dto.response;
 
 import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
+import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 
 public record MemberProfileResponse(
@@ -9,7 +10,7 @@ public record MemberProfileResponse(
         String nickname,
         String studentId,
         String phoneNumber,
-        String gender,
+        Gender gender,
         String major,
         int maximumTicket,
         int remainingTicket,
@@ -24,8 +25,8 @@ public record MemberProfileResponse(
                 member.getNickname(),
                 member.getStudentId(),
                 member.getPhoneNumber(),
-                member.getGender() != null ? member.getGender().getName() : "Unknown",
-                member.getMajor() != null ? member.getMajor().getDepartment() : "Unknown",
+                member.getGender(),
+                member.getMajor().getDepartment(),
                 member.getMaximumTicket(),
                 member.getRemainingTicket(),
                 ImageResponse.fromEntity(profileImage)

--- a/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/dto/response/MemberResponse.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.member.dto.response;
 
 import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
+import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 
 public record MemberResponse(
@@ -12,7 +13,7 @@ public record MemberResponse(
         String loginId,
         String loginPassword,
         String phoneNumber,
-        String gender,
+        Gender gender,
         String major,
         ImageResponse profileImage
 ) {
@@ -28,7 +29,7 @@ public record MemberResponse(
                 member.getLoginId(),
                 member.getLoginPassword(),
                 member.getPhoneNumber(),
-                member.getGender().getName(),
+                member.getGender(),
                 member.getMajor().getDepartment(),
                 ImageResponse.fromEntity(profileImage)
         );

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -108,6 +108,8 @@ public class RoomService {
                 request.place(),
                 request.content(),
                 request.preferredGender(),
+                request.preferredStudentIdMin(),
+                request.preferredStudentIdMax(),
                 request.meetingDateTime(),
                 request.maxParticipants()
         );

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -10,7 +10,6 @@ import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
 import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.image.domain.RoomImage;
 import com.gobongbob.festamate.domain.image.infrastructure.ImageService;
-import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Role;
 import com.gobongbob.festamate.domain.room.domain.Room;
@@ -108,7 +107,7 @@ public class RoomService {
                 request.title(),
                 request.place(),
                 request.content(),
-                Gender.findByName(request.preferredGender()),
+                request.preferredGender(),
                 request.meetingDateTime(),
                 request.maxParticipants()
         );

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -14,9 +14,9 @@ import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Role;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
+import com.gobongbob.festamate.domain.room.dto.request.FilteringCondition;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
-import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
@@ -70,8 +70,8 @@ public class RoomService {
         return chatRoom;
     }
 
-    public Slice<RoomListResponse> findBySearchCondition(Pageable pageable, SearchCondition searchCondition) {
-        return roomRepository.findBySearchCondition(pageable, searchCondition)
+    public Slice<RoomListResponse> findBySearchCondition(Pageable pageable, FilteringCondition filteringCondition) {
+        return roomRepository.findBySearchCondition(pageable, filteringCondition)
                 .map(room -> RoomListResponse.fromEntity(
                         room,
                         roomParticipantRepository.countByRoom_Id(room.getId())

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -49,6 +49,10 @@ public class Room {
     @Enumerated(EnumType.STRING)
     private Gender preferredGender;
 
+    private String preferredStudentIdMin;
+
+    private String preferredStudentIdMax;
+
     private LocalDateTime meetingDateTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -70,6 +74,8 @@ public class Room {
             String place,
             String content,
             Gender preferredGender,
+            String preferredStudentIdMin,
+            String preferredStudentIdMax,
             LocalDateTime meetingDateTime,
             int maxParticipants
     ) {
@@ -77,6 +83,8 @@ public class Room {
         this.place = place;
         this.content = content;
         this.preferredGender = preferredGender;
+        this.preferredStudentIdMin = preferredStudentIdMin;
+        this.preferredStudentIdMax = preferredStudentIdMax;
         this.meetingDateTime = meetingDateTime;
         this.maxParticipants = maxParticipants;
     }

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/FilteringCondition.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/FilteringCondition.java
@@ -3,7 +3,7 @@ package com.gobongbob.festamate.domain.room.dto.request;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Status;
 
-public record SearchCondition(
+public record FilteringCondition(
         Status status,
         Gender gender,
         String minStudentId,

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
@@ -12,6 +12,8 @@ public record RoomCreateRequest(
         @Size(max = 10, message = "장소는 최대 10자까지 입력 가능합니다") String place,
         @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
         Gender preferredGender,
+        String preferredStudentIdMin,
+        String preferredStudentIdMax,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants
@@ -23,6 +25,8 @@ public record RoomCreateRequest(
                 .place(place)
                 .content(content)
                 .preferredGender(preferredGender)
+                .preferredStudentIdMin(preferredStudentIdMin)
+                .preferredStudentIdMax(preferredStudentIdMax)
                 .meetingDateTime(meetingDateTime)
                 .maxParticipants(maxParticipants)
                 .host(member)

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomCreateRequest.java
@@ -11,7 +11,7 @@ public record RoomCreateRequest(
         @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다") String title,
         @Size(max = 10, message = "장소는 최대 10자까지 입력 가능합니다") String place,
         @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
-        String preferredGender,
+        Gender preferredGender,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants
@@ -22,7 +22,7 @@ public record RoomCreateRequest(
                 .title(title)
                 .place(place)
                 .content(content)
-                .preferredGender(Gender.findByName(preferredGender))
+                .preferredGender(preferredGender)
                 .meetingDateTime(meetingDateTime)
                 .maxParticipants(maxParticipants)
                 .host(member)

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
@@ -11,6 +11,8 @@ public record RoomUpdateRequest(
         @Size(max = 10, message = "장소는 최대 10자까지 입력 가능합니다") String place,
         @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
         Gender preferredGender,
+        String preferredStudentIdMin,
+        String preferredStudentIdMax,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants
@@ -22,6 +24,8 @@ public record RoomUpdateRequest(
                 .place(place)
                 .content(content)
                 .preferredGender(preferredGender)
+                .preferredStudentIdMin(preferredStudentIdMin)
+                .preferredStudentIdMax(preferredStudentIdMax)
                 .meetingDateTime(meetingDateTime)
                 .maxParticipants(maxParticipants)
                 .build();

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/RoomUpdateRequest.java
@@ -10,7 +10,7 @@ public record RoomUpdateRequest(
         @Size(max = 20, message = "제목은 최대 20자까지 입력 가능합니다") String title,
         @Size(max = 10, message = "장소는 최대 10자까지 입력 가능합니다") String place,
         @Size(max = 200, message = "글 내용은 최대 200자까지 입력 가능합니다") String content,
-        String preferredGender,
+        Gender preferredGender,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants
@@ -21,7 +21,7 @@ public record RoomUpdateRequest(
                 .title(title)
                 .place(place)
                 .content(content)
-                .preferredGender(Gender.findByName(preferredGender))
+                .preferredGender(preferredGender)
                 .meetingDateTime(meetingDateTime)
                 .maxParticipants(maxParticipants)
                 .build();

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
@@ -6,6 +6,8 @@ import com.gobongbob.festamate.domain.room.domain.Status;
 public record SearchCondition(
         Status status,
         Gender gender,
+        String minStudentId,
+        String maxStudentId,
         Integer participants,
         String studentId
 ) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/request/SearchCondition.java
@@ -2,12 +2,9 @@ package com.gobongbob.festamate.domain.room.dto.request;
 
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Status;
-import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SearchCondition(
-        @Schema(description = "매칭 상태", enumAsRef = true)
         Status status,
-        @Schema(description = "입장 가능 성별", enumAsRef = true)
         Gender gender,
         Integer participants,
         String studentId

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
@@ -15,6 +15,8 @@ public record RoomListResponse(
         String place,
         String content,
         Gender preferredGender,
+        String preferredStudentIdMin,
+        String preferredStudentIdMax,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
@@ -32,6 +34,8 @@ public record RoomListResponse(
                 room.getPlace(),
                 room.getContent(),
                 room.getPreferredGender(),
+                room.getPreferredStudentIdMin(),
+                room.getPreferredStudentIdMax(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
                 currentParticipants,

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
@@ -3,6 +3,7 @@ package com.gobongbob.festamate.domain.room.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
+import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.Status;
 import java.time.LocalDateTime;
@@ -13,7 +14,7 @@ public record RoomListResponse(
         Status status,
         String place,
         String content,
-        String preferredGender,
+        Gender preferredGender,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
@@ -30,7 +31,7 @@ public record RoomListResponse(
                 room.getStatus(),
                 room.getPlace(),
                 room.getContent(),
-                room.getPreferredGender().getName(),
+                room.getPreferredGender(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
                 currentParticipants,

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -16,6 +16,8 @@ public record RoomResponse(
         String place,
         String content,
         Gender preferredGender,
+        String preferredStudentIdMin,
+        String preferredStudentIdMax,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
@@ -36,6 +38,8 @@ public record RoomResponse(
                 room.getPlace(),
                 room.getContent(),
                 room.getPreferredGender(),
+                room.getPreferredStudentIdMin(),
+                room.getPreferredStudentIdMax(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
                 toParticipantResponse(hostParticipants),

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.room.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.image.dto.response.ImageResponse;
+import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
 import com.gobongbob.festamate.domain.room.domain.Status;
@@ -14,7 +15,7 @@ public record RoomResponse(
         Status status,
         String place,
         String content,
-        String preferredGender,
+        Gender preferredGender,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
@@ -34,7 +35,7 @@ public record RoomResponse(
                 room.getStatus(),
                 room.getPlace(),
                 room.getContent(),
-                room.getPreferredGender().getName(),
+                room.getPreferredGender(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
                 toParticipantResponse(hostParticipants),

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepository.java
@@ -1,11 +1,11 @@
 package com.gobongbob.festamate.domain.room.persistence;
 
 import com.gobongbob.festamate.domain.room.domain.Room;
-import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
+import com.gobongbob.festamate.domain.room.dto.request.FilteringCondition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface RoomQueryDslRepository {
 
-    Slice<Room> findBySearchCondition(Pageable pageable, SearchCondition searchCondition);
+    Slice<Room> findBySearchCondition(Pageable pageable, FilteringCondition filteringCondition);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -6,7 +6,7 @@ import static org.springframework.util.StringUtils.hasText;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.Status;
-import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
+import com.gobongbob.festamate.domain.room.dto.request.FilteringCondition;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -27,16 +27,16 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
      * 모임 상태, 학과, 학번, 성별에 따른 조회
      */
     @Override
-    public Slice<Room> findBySearchCondition(Pageable pageable, SearchCondition searchCondition) {
+    public Slice<Room> findBySearchCondition(Pageable pageable, FilteringCondition filteringCondition) {
         int pageSize = pageable.getPageSize();
 
         JPAQuery<Room> basicQuery = queryFactory
                 .selectFrom(room)
                 .where(
-                        statusEquals(searchCondition.status()),
-                        genderEquals(searchCondition.gender()),
-                        participantsEquals(searchCondition.participants()),
-                        studentIdContains(searchCondition.minStudentId(), searchCondition.maxStudentId())
+                        statusEquals(filteringCondition.status()),
+                        genderEquals(filteringCondition.gender()),
+                        participantsEquals(filteringCondition.participants()),
+                        studentIdContains(filteringCondition.minStudentId(), filteringCondition.maxStudentId())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageSize + 1);

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -35,8 +35,8 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
                 .where(
                         statusEquals(searchCondition.status()),
                         genderEquals(searchCondition.gender()),
-                        participantsEquals(searchCondition.participants())
-//                                ,studentIdContains(searchCondition.studentId())
+                        participantsEquals(searchCondition.participants()),
+                        studentIdContains(searchCondition.minStudentId(), searchCondition.maxStudentId())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageSize + 1);
@@ -83,16 +83,14 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
         return null;
     }
 
-    // 방 안에 입력받은 학번을 가진 사람이 있는지 확인
-    // Room 엔티티에 선호 학번이 들어가야 구현 가능하므로, 추후 구현할 예정
-//    private BooleanExpression studentIdContains(String studentId) {
-//        JPQLQuery<Long> roomIdsOfStudentIdMatched = queryFactory
-//                .select(roomParticipant.room.id)
-//                .from(roomParticipant)
-//                .where(roomParticipant.member.studentId.startsWith(studentId));
-//
-//        return room.id.in(roomIdsOfStudentIdMatched);
-//    }
+    private BooleanExpression studentIdContains(String minStudentId, String maxStudentId) {
+        if (hasText(minStudentId) && hasText(minStudentId)) {
+            // 모임방의 최소 학번 조건이 25일 경우 24는 통과하고, 최대 학번 조건이 20일 경우 19는 통과하지 못함
+            return room.preferredStudentIdMin.goe(minStudentId).and(room.preferredStudentIdMax.loe(maxStudentId));
+        }
+
+        return null;
+    }
 
     /*
       정렬 관련 쿼리를 추가하기 위한 메소드

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomQueryDslRepositoryImpl.java
@@ -84,7 +84,7 @@ public class RoomQueryDslRepositoryImpl implements RoomQueryDslRepository {
     }
 
     private BooleanExpression studentIdContains(String minStudentId, String maxStudentId) {
-        if (hasText(minStudentId) && hasText(minStudentId)) {
+        if (hasText(minStudentId) && hasText(maxStudentId)) {
             // 모임방의 최소 학번 조건이 25일 경우 24는 통과하고, 최대 학번 조건이 20일 경우 19는 통과하지 못함
             return room.preferredStudentIdMin.goe(minStudentId).and(room.preferredStudentIdMax.loe(maxStudentId));
         }

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -73,7 +73,11 @@ public class RoomController {
         return new SuccessResponse<>();
     }
 
-    @Operation(summary = "필터에 따른 모임방 조회", description = "필터에 따라 방 목록을 무한 스크롤 방식으로 조회합니다.")
+    @Operation(summary = "필터에 따른 모임방 조회", description = """
+            필터에 따라 방 목록을 무한 스크롤 방식으로 조회합니다. gender 및 status로 전달할 수 있는 값은 다음과 같습니다.
+            <br><br>gender: [MALE, FEMALE] (남성, 여성)
+            <br>status: [MATCHING, MATCHED, CLOSED] (매칭중, 매칭 완료, 모임 종료)
+            """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.")
     })
@@ -81,7 +85,7 @@ public class RoomController {
     public SuccessResponse<Slice<RoomListResponse>> findBySearchCondition(
             @Parameter(description = "페이징 정보")
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-            @Parameter(description = "필터링 조건")
+            @Parameter(description = "필터링 정보")
             @ModelAttribute SearchCondition searchCondition
     ) {
         return new SuccessResponse<>(roomService.findBySearchCondition(pageable, searchCondition));
@@ -111,7 +115,10 @@ public class RoomController {
         return new SuccessResponse<>(roomService.findRoomById(roomId));
     }
 
-    @Operation(summary = "모임방 정보 수정", description = "모임방 정보를 수정합니다.")
+    @Operation(summary = "모임방 정보 수정", description = """
+            모임방 정보를 수정합니다. gender로 전달할 수 있는 값은 다음과 같습니다.
+            <br><br>gender: [MALE, FEMALE] (남성, 여성)
+            """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
             @ApiResponse(responseCode = "400", description = "모임방이 존재하지 않습니다.")

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -5,9 +5,9 @@ import com.gobongbob.festamate.domain.chat.application.ChatService;
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.room.application.RoomParticipationService;
 import com.gobongbob.festamate.domain.room.application.RoomService;
+import com.gobongbob.festamate.domain.room.dto.request.FilteringCondition;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
-import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.IsMemberHostResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
@@ -86,9 +86,9 @@ public class RoomController {
             @Parameter(description = "페이징 정보")
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @Parameter(description = "필터링 정보")
-            @ModelAttribute SearchCondition searchCondition
+            @ModelAttribute FilteringCondition filteringCondition
     ) {
-        return new SuccessResponse<>(roomService.findBySearchCondition(pageable, searchCondition));
+        return new SuccessResponse<>(roomService.findBySearchCondition(pageable, filteringCondition));
     }
 
     @Operation(summary = "참여 중인 모임방 조회", description = "사용자가 참여 중인 방 목록을 조회합니다.")

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -17,9 +17,9 @@ import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.domain.Status;
+import com.gobongbob.festamate.domain.room.dto.request.FilteringCondition;
 import com.gobongbob.festamate.domain.room.dto.request.RoomCreateRequest;
 import com.gobongbob.festamate.domain.room.dto.request.RoomUpdateRequest;
-import com.gobongbob.festamate.domain.room.dto.request.SearchCondition;
 import com.gobongbob.festamate.domain.room.dto.response.RoomListResponse;
 import com.gobongbob.festamate.domain.room.dto.response.RoomResponse;
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
@@ -125,7 +125,7 @@ class RoomServiceTest extends serviceSliceTest {
             rooms.forEach(room -> testFixtureBuilder.buildRoom(room));
 
             Pageable pageable = PageRequest.of(0, 10);
-            SearchCondition searchCondition = new SearchCondition(
+            FilteringCondition filteringCondition = new FilteringCondition(
                     Status.MATCHING,
                     Gender.MALE,
                     4,
@@ -133,7 +133,7 @@ class RoomServiceTest extends serviceSliceTest {
             );
 
             // when
-            Slice<RoomListResponse> findRoomResponses = roomService.findBySearchCondition(pageable, searchCondition);
+            Slice<RoomListResponse> findRoomResponses = roomService.findBySearchCondition(pageable, filteringCondition);
 
             // then
             assertThat(findRoomResponses).hasSize(rooms.size());

--- a/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
+++ b/src/test/java/com/gobongbob/festamate/domain/room/application/RoomServiceTest.java
@@ -128,6 +128,8 @@ class RoomServiceTest extends serviceSliceTest {
             FilteringCondition filteringCondition = new FilteringCondition(
                     Status.MATCHING,
                     Gender.MALE,
+                    "25",
+                    "20",
                     4,
                     "20"
             );
@@ -161,7 +163,9 @@ class RoomServiceTest extends serviceSliceTest {
                     room.getTitle(),
                     room.getPlace(),
                     room.getContent(),
-                    preferredGenderToUpdate.getName(),
+                    preferredGenderToUpdate,
+                    room.getPreferredStudentIdMin(),
+                    room.getPreferredStudentIdMax(),
                     room.getMeetingDateTime(),
                     maxParticipantsToUpdate
             );


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #137

### 📝 작업 내용
- Room 엔티티에 학번 조건 관련 필드를 추가했으며, 이에 따라 관련 DTO를 수정했습니다.
- 학번의 범위 조건을 이용해 모임방을 조회할 수 있도록 기능을 추가했습니다.
  - ex. 25 ~ 22 학번의 범위로 필터링을 건 경우, 25 ~ 24 학번을 원하는 모임은 조회되지 않음

### 📷 스크린샷 (선택)

- JSON 응답은 다음과 같습니다.
```json
{
    "id": 5,
    "title": "test title1",
    "status": "MATCHING",
    "place": "8강의동 흡연장",
    "content": "test content1",
    "preferredGender": "MALE",
    "preferredStudentIdMin": "24",
    "preferredStudentIdMax": "20",
    "meetingDateTime": "2025-02-26 22:07:42",
    "maxParticipants": 4,
    "currentParticipants": 1,
    "thumbnail": {
        "name": "db5a5db4-d7a5-466f-899f-91ac0218941b.jpeg",
        "url": "https://festamate-bucket.s3.ap-northeast-2.amazonaws.com/db5a5db4-d7a5-466f-899f-91ac0218941b.jpeg"
    }
}
```

### 💬 리뷰 요구사항 (선택)
```json
"preferredStudentIdMin": "24",
"preferredStudentIdMax": "20",
```

대충 학번 조건이 요렇게 표시된다는 것만 확인하시면 될 듯 합니다!
