### PR TITLE
모임방 수정 기능에 이미지 수정 로직 추가

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/image/infrastructure/ImageService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/infrastructure/ImageService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.StreamUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -57,5 +58,11 @@ public class ImageService {
         } catch (IOException e) {
             throw new RuntimeException("파일 업로드에 실패했습니다.", e);
         }
+    }
+
+    @Transactional
+    public void delete(Image image) {
+        String storeName = image.getStoreName();
+        amazonS3Client.deleteObject(bucket, storeName);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/image/persistence/RoomImageRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/image/persistence/RoomImageRepository.java
@@ -1,0 +1,8 @@
+package com.gobongbob.festamate.domain.image.persistence;
+
+import com.gobongbob.festamate.domain.image.domain.RoomImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomImageRepository extends JpaRepository<RoomImage, Long> {
+
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -105,18 +105,24 @@ public class RoomService {
         validateIsHost(room, member);
         validateAlone(room);
 
-        List<RoomImage> roomImages;
-        if (!imageFiles.isEmpty()) {
-            room.getImages()
-                    .forEach(roomImage -> imageService.delete(roomImage.getImage()));
-            room.getImages().clear();
+        imageFiles.stream()
+                .filter(imageFile -> imageFile == null || imageFile.isEmpty())
+                .findAny()
+                .ifPresentOrElse(
+                        imageFile -> {
+                        },
+                        () -> {
+                            room.getImages()
+                                    .forEach(roomImage -> imageService.delete(roomImage.getImage()));
+                            room.getImages().clear();
 
-            roomImages = imageService.uploadImages(imageFiles)
-                    .stream()
-                    .map(RoomImage::fromEntity)
-                    .toList();
-            room.assignImages(roomImages);
-        }
+                            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
+                                    .stream()
+                                    .map(RoomImage::fromEntity)
+                                    .toList();
+                            room.assignImages(roomImages);
+                        }
+                );
 
         room.updateRoom(
                 request.title(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -10,6 +10,7 @@ import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
 import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.image.domain.RoomImage;
 import com.gobongbob.festamate.domain.image.infrastructure.ImageService;
+import com.gobongbob.festamate.domain.image.persistence.RoomImageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.room.domain.Role;
 import com.gobongbob.festamate.domain.room.domain.Room;
@@ -37,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final RoomImageRepository roomImageRepository;
     private final RoomParticipantRepository roomParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
@@ -102,6 +104,19 @@ public class RoomService {
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
         validateAlone(room);
+
+        List<RoomImage> roomImages;
+        if (!imageFiles.isEmpty()) {
+            room.getImages()
+                    .forEach(roomImage -> imageService.delete(roomImage.getImage()));
+            room.getImages().clear();
+
+            roomImages = imageService.uploadImages(imageFiles)
+                    .stream()
+                    .map(RoomImage::fromEntity)
+                    .toList();
+            room.assignImages(roomImages);
+        }
 
         room.updateRoom(
                 request.title(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -97,7 +97,7 @@ public class RoomService {
     }
 
     @Transactional
-    public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request) {
+    public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request, List<MultipartFile> imageFiles) {
         Room room = roomRepository.findByIdWithHost(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -65,7 +65,7 @@ public class Room {
 
     // 연관관계 편의 메서드
     public void assignImages(List<RoomImage> roomImages) {
-        this.images = roomImages;
+        this.images.addAll(roomImages);
         roomImages.forEach(roomImage -> roomImage.setRoom(this));
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomApi.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomApi.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -97,8 +96,10 @@ public interface RoomApi {
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @Parameter(name = "roomId", description = "모임방 ID") @PathVariable("roomId") Long roomId,
-            @Parameter(description = "모임방 수정 요청 정보")
-            @RequestBody @Valid RoomUpdateRequest request
+            @Parameter(description = "방 수정 요청 정보")
+            @RequestPart("request") @Valid RoomUpdateRequest request,
+            @Parameter(description = "방 이미지")
+            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> multipartFiles
     );
 
     @Operation(summary = "모임방 삭제", description = "모임방을 삭제합니다.")

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -88,9 +87,10 @@ public class RoomController implements RoomApi {
     public SuccessResponse<Void> updateById(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("roomId") Long roomId,
-            @RequestBody @Valid RoomUpdateRequest request
+            @RequestPart("request") @Valid RoomUpdateRequest request,
+            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> multipartFiles
     ) {
-        roomService.updateRoomById(memberDetails.getMember(), roomId, request);
+        roomService.updateRoomById(memberDetails.getMember(), roomId, request, multipartFiles);
 
         return new SuccessResponse<>();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
   security:
     oauth2:


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #142 

### 📝 작업 내용
- 모임방 수정 시, 기존 이미지를 삭제하고 새로운 이미지를 업로드하도록 로직을 추가했습니다.
- 모임방 수정 요청을 `application/json`이 아닌 `multipart/form-data`로 받도록 수정했습니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

