### PR TITLE
호스트의 모임방 퇴장 시, 방이 삭제되는 로직 추가

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -59,6 +59,7 @@ public class RoomParticipationService {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateNotHost(room, member);
+        validateRoomMatching(room);
 
         List<RoomParticipant> guestParticipants = roomParticipantRepository.findByRoomAndRole(roomId,
                 ParticipantRole.GUEST);

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -4,6 +4,7 @@ import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
+import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import com.gobongbob.festamate.domain.room.domain.ParticipantRole;
@@ -29,6 +30,7 @@ public class RoomParticipationService {
 
     private final RoomRepository roomRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
     private final RoomParticipantRepository roomParticipantRepository;
     private final MemberRepository memberRepository;
 
@@ -61,6 +63,12 @@ public class RoomParticipationService {
         List<RoomParticipant> guestParticipants = roomParticipantRepository.findByRoomAndRole(roomId,
                 ParticipantRole.GUEST);
         roomParticipantRepository.deleteAll(guestParticipants);
+
+        if (member.isHost(room)) { // 방장이 방을 나가면 방을 삭제
+            messageRepository.deleteByRoomId(roomId);
+            chatRoomRepository.deleteByRoomId(roomId);
+            roomRepository.delete(room);
+        }
 
         return chatRoomRepository.findByRoom(room)
                 .orElseThrow(() -> new BadRequestException(CHAT_ROOM_NOT_FOUND));

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -95,6 +95,7 @@ public class RoomService {
         return roomRepository.findById(roomId)
                 .map(room -> RoomResponse.fromEntity(
                         room,
+                        roomParticipantRepository.countByRoom_Id(room.getId()),
                         findRoomAuthorityByMember(room, memberDetails),
                         roomParticipantRepository.findByRoomAndRole(room.getId(), ParticipantRole.HOST),
                         roomParticipantRepository.findByRoomAndRole(room.getId(), ParticipantRole.GUEST)

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -22,6 +22,7 @@ public record RoomResponse(
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime meetingDateTime,
         int maxParticipants,
+        int currentParticipants,
         RoomAuthority roomAuthority,
         List<ParticipantResponse> hostParticipants,
         List<ParticipantResponse> guestParticipants,
@@ -30,6 +31,7 @@ public record RoomResponse(
 
     public static RoomResponse fromEntity(
             Room room,
+            int currentParticipants,
             RoomAuthority roomAuthority,
             List<RoomParticipant> hostParticipants,
             List<RoomParticipant> guestParticipants
@@ -45,6 +47,7 @@ public record RoomResponse(
                 room.getPreferredStudentIdMax(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
+                currentParticipants,
                 roomAuthority,
                 toParticipantResponse(hostParticipants),
                 toParticipantResponse(guestParticipants),


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #178 

### 📝 작업 내용
- 호스트가 방을 나갔을 때, 방이 모두 삭제되도록 수정
- 매칭이 완료된 방은 나갈 수 없도록 로직 추가

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

