### PR TITLE
모임 생성 시, 사진을 첨부하지 않았을 때 랜덤한 이미지가 추가되는 로직 추가

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomImagePicker.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomImagePicker.java
@@ -1,0 +1,29 @@
+package com.gobongbob.festamate.domain.room.application;
+
+import java.util.List;
+import java.util.Random;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoomImagePicker {
+
+    private static final List<String> IMAGE_URLS = List.of(
+            "https://plus.unsplash.com/premium_photo-1681830682381-478268dcc5d6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NXx8Y29sbGVnZSUyMGZlc3RpdmFsfGVufDB8fDB8fHww",
+            "https://plus.unsplash.com/premium_photo-1681841804755-3baa70b97a6c?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTN8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1681830968052-1c3676fb8117?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTd8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1681830977092-adafd313f327?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MjV8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://images.unsplash.com/photo-1656137631992-efcfe6b23ce9?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MzJ8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1681830932665-8c9a53a9e731?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MzN8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1681830693025-42932def62f7?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NDl8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://images.unsplash.com/photo-1576646722964-470f2b45ecfc?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NTZ8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1658507039120-b886e903c542?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NTd8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D",
+            "https://plus.unsplash.com/premium_photo-1681830943606-bfab210b17e6?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NjF8fGNvbGxlZ2UlMjBmZXN0aXZhbHxlbnwwfHwwfHx8MA%3D%3D"
+    );
+
+    private final Random random = new Random();
+
+    public String getRandomImageUrl() {
+        int index = random.nextInt(IMAGE_URLS.size());
+        return IMAGE_URLS.get(index);
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -55,14 +55,14 @@ public class RoomService {
 
         Room createdRoom = roomRepository.save(request.toEntity(member));
 
-        if (imageFiles != null) {
+        if (imageFiles != null && !imageFiles.isEmpty()) {
             List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
                     .stream()
                     .map(RoomImage::fromEntity)
                     .toList();
             createdRoom.assignImages(roomImages);
         }
-        if (imageFiles == null) {
+        if (imageFiles == null || imageFiles.isEmpty()) {
             Image image = pickRandomImage();
             RoomImage roomImage = RoomImage.fromEntity(image);
             createdRoom.assignImages(List.of(roomImage));
@@ -124,7 +124,7 @@ public class RoomService {
         validateIsHost(room, member);
         validateAlone(room);
 
-        if (imageFiles != null) {
+        if (imageFiles != null && !imageFiles.isEmpty()) {
             room.getImages().forEach(roomImage -> imageService.delete(roomImage.getImage()));
             room.getImages().clear();
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -6,9 +6,9 @@ import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
 import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
+import com.gobongbob.festamate.domain.image.domain.Image;
 import com.gobongbob.festamate.domain.image.domain.RoomImage;
 import com.gobongbob.festamate.domain.image.infrastructure.ImageService;
-import com.gobongbob.festamate.domain.image.persistence.RoomImageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import com.gobongbob.festamate.domain.room.domain.ParticipantRole;
@@ -25,6 +25,7 @@ import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -38,7 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class RoomService {
 
     private final RoomRepository roomRepository;
-    private final RoomImageRepository roomImageRepository;
+    private final RoomImagePicker roomImagePicker;
     private final RoomParticipantRepository roomParticipantRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
@@ -54,14 +55,17 @@ public class RoomService {
 
         Room createdRoom = roomRepository.save(request.toEntity(member));
 
-        boolean isImageFileExist = imageFiles.stream()
-                .allMatch(imageFile -> imageFile != null && !imageFile.isEmpty());
-        if (isImageFileExist) {
+        if (imageFiles != null) {
             List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
                     .stream()
                     .map(RoomImage::fromEntity)
                     .toList();
             createdRoom.assignImages(roomImages);
+        }
+        if (imageFiles == null) {
+            Image image = pickRandomImage();
+            RoomImage roomImage = RoomImage.fromEntity(image);
+            createdRoom.assignImages(List.of(roomImage));
         }
 
         ChatRoom chatRoom = ChatRoom.builder()
@@ -120,10 +124,7 @@ public class RoomService {
         validateIsHost(room, member);
         validateAlone(room);
 
-        boolean isImageFileExist = imageFiles.stream()
-                .allMatch(imageFile -> imageFile != null && !imageFile.isEmpty());
-
-        if (isImageFileExist) {
+        if (imageFiles != null) {
             room.getImages().forEach(roomImage -> imageService.delete(roomImage.getImage()));
             room.getImages().clear();
 
@@ -176,6 +177,16 @@ public class RoomService {
                 .map(participant -> participant.isHost() ? RoomAuthority.HOST
                         : RoomAuthority.PARTICIPANT)
                 .orElse(RoomAuthority.NON_PARTICIPANT);
+    }
+
+    private Image pickRandomImage() {
+        String randomImageUrl = roomImagePicker.getRandomImageUrl();
+
+        return Image.builder()
+                .url(randomImageUrl)
+                .uploadName(UUID.randomUUID().toString())
+                .storeName(UUID.randomUUID().toString())
+                .build();
     }
 
     private void validateRoomParticipation(Long memberId) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -1,10 +1,6 @@
 package com.gobongbob.festamate.domain.room.application;
 
-import static com.gobongbob.festamate.global.response.ResponseCode.ALREADY_PARTICIPATING;
-import static com.gobongbob.festamate.global.response.ResponseCode.CAN_NOT_UPDATE;
-import static com.gobongbob.festamate.global.response.ResponseCode.MUST_HOST;
-import static com.gobongbob.festamate.global.response.ResponseCode.NOT_FOUND_ROOM;
-import static com.gobongbob.festamate.global.response.ResponseCode.NO_MEMBER;
+import static com.gobongbob.festamate.global.response.ResponseCode.*;
 
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
@@ -28,7 +24,6 @@ import com.gobongbob.festamate.domain.room.persistence.RoomParticipantRepository
 import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -53,22 +48,21 @@ public class RoomService {
     // 방 생성
     @Transactional
     @CheckActiveUser // 메서드 실행 전 현재 사용자가 ACTIVE 상태인지 AOP로 확인 (BLOCKED 시 AccessDeniedException 발생)
-    public ChatRoom createRoom(Long memberId, RoomCreateRequest request,
-            List<MultipartFile> imageFiles) {
-        Member member = memberRepository.findById(
-                        memberId) // 티켓 소모를 위해 영속성 컨텍스트에서 관리하는 member 객체를 재조회
+    public ChatRoom createRoom(Long memberId, RoomCreateRequest request, List<MultipartFile> imageFiles) {
+        Member member = memberRepository.findById(memberId) // 티켓 소모를 위해 영속성 컨텍스트에서 관리하는 member 객체를 재조회
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
 
-        List<RoomImage> roomImages = new ArrayList<>();
-        if (!imageFiles.isEmpty()) {
-            roomImages = imageService.uploadImages(imageFiles)
+        Room createdRoom = roomRepository.save(request.toEntity(member));
+
+        boolean isImageFileExist = imageFiles.stream()
+                .allMatch(imageFile -> imageFile != null && !imageFile.isEmpty());
+        if (isImageFileExist) {
+            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
                     .stream()
                     .map(RoomImage::fromEntity)
                     .toList();
+            createdRoom.assignImages(roomImages);
         }
-
-        Room createdRoom = roomRepository.save(request.toEntity(member));
-        createdRoom.assignImages(roomImages);
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .name(createdRoom.getTitle())
@@ -126,25 +120,19 @@ public class RoomService {
         validateIsHost(room, member);
         validateAlone(room);
 
-        imageFiles.stream()
-                .filter(imageFile -> imageFile == null || imageFile.isEmpty())
-                .findAny()
-                .ifPresentOrElse(
-                        imageFile -> {
-                        },
-                        () -> {
-                            room.getImages()
-                                    .forEach(
-                                            roomImage -> imageService.delete(roomImage.getImage()));
-                            room.getImages().clear();
+        boolean isImageFileExist = imageFiles.stream()
+                .allMatch(imageFile -> imageFile != null && !imageFile.isEmpty());
 
-                            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
-                                    .stream()
-                                    .map(RoomImage::fromEntity)
-                                    .toList();
-                            room.assignImages(roomImages);
-                        }
-                );
+        if (isImageFileExist) {
+            room.getImages().forEach(roomImage -> imageService.delete(roomImage.getImage()));
+            room.getImages().clear();
+
+            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
+                    .stream()
+                    .map(RoomImage::fromEntity)
+                    .toList();
+            room.assignImages(roomImages);
+        }
 
         room.updateRoom(
                 request.title(),

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
@@ -2,12 +2,7 @@ package com.gobongbob.festamate.global.util;
 
 import com.gobongbob.festamate.domain.auth.jwt.domain.TokenType;
 import com.gobongbob.festamate.domain.member.domain.Member;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.JwtBuilder;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -35,9 +30,9 @@ public class TokenProvider {
 
     // 토큰 생성 (TokenType에 따라 다르게 생성)
     public Map<String, String> generateTokens(Member member, TokenType type) {
-        String accessToken = createToken(member, "access", TokenType.FINAL_ACCESS.getDuration(),
+        String accessToken = createToken(member, "access", type.getDuration(),
                 TokenType.FINAL_ACCESS);
-        String refreshToken = createToken(member, "refresh", TokenType.FINAL_REFRESH.getDuration(),
+        String refreshToken = createToken(member, "refresh", type.getDuration(),
                 TokenType.FINAL_REFRESH);
 
         Map<String, String> tokens = new HashMap<>();
@@ -88,8 +83,7 @@ public class TokenProvider {
     }
 
     /**
-     * 토큰의 유효성을 검증합니다.
-     * 유효하지 않은 경우 BadCredentialsException을 던져 JwtAuthenticationEntryPoint가 동작하도록 유도합니다.
+     * 토큰의 유효성을 검증합니다. 유효하지 않은 경우 BadCredentialsException을 던져 JwtAuthenticationEntryPoint가 동작하도록 유도합니다.
      *
      * @param token 검증할 JWT 토큰
      * @throws BadCredentialsException 토큰이 유효하지 않을 때 (서명 오류, 만료, 형식 오류 등)

--- a/src/main/java/com/gobongbob/festamate/testUser/TestService.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestService.java
@@ -2,7 +2,6 @@ package com.gobongbob.festamate.testUser;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.gobongbob.festamate.domain.auth.jwt.domain.TokenType;
-import com.gobongbob.festamate.domain.image.domain.ProfileImage;
 import com.gobongbob.festamate.domain.image.persistence.ProfileImageRepository;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
@@ -11,7 +10,6 @@ import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
 import com.gobongbob.festamate.global.util.TokenProvider;
 import jakarta.transaction.Transactional;
 import java.util.Map;
-import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -107,11 +105,8 @@ public class TestService {
         }
 
         // 초기 프로필 이미지 설정 (DB에 기본 이미지가 있다고 가정)
-        Optional<ProfileImage> defaultProfileImage = profileImageRepository.findByStoreName(
-                profileImageName);
-        if (defaultProfileImage.isPresent()) {
-            member.initializeProfileImage(defaultProfileImage.get());
-        }
+        profileImageRepository.findByStoreName(profileImageName)
+                .ifPresent(member::initializeProfileImage);
 
         // DB에 회원 저장
         Member savedMember = memberRepository.save(member);


### PR DESCRIPTION
### #️⃣ 연관된 이슈
close #193 

### 📝 작업 내용
- 모임 생성 시, 사진을 첨부하지 않아도 예외를 발생시키지 않도록 수정
- 사용자가 전송한 사진이 없을 경우, 기본 사진 중 하나를 랜덤으로 추가하도록 로직 추가
- 테스트 유저 생성 시, 토큰의 유효기간이 테스트용으로 설정되지 않는 오류 수정

### 📷 스크린샷 
- 모임 생성 및 수정 시, 아래 이미지처럼 `imageFiles` Key를 첨부하지 않아도 정상적으로 요청에 성공합니다.
![스크린샷 2025-04-24 오후 9 51 57](https://github.com/user-attachments/assets/4ca30de6-acb1-4d1e-8a08-d327f72848b2)


### 💬 리뷰 요구사항 (선택)

