### PR TITLE
JWT 만료 시, 401 에러코드가 아닌 500 에러코드가 발생하는 오류 수정

### DIFF
--- a/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
@@ -43,7 +43,13 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String token = getAccessToken(authorizationHeader);
 
         // 토큰 유효성 검사
-        if (token != null && tokenProvider.validateToken(token)) {
+        if (token != null) {
+            if (!tokenProvider.validateToken(token)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+                return;
+            }
+
             Authentication authentication = tokenProvider.getAuthentication(token);
             Object principal = authentication.getPrincipal();
 

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenProvider.java
@@ -97,17 +97,8 @@ public class TokenProvider {
                     .getBody();
 
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            // JwtException 또는 IllegalArgumentException 발생 시
-            // BadCredentialsException을 던져 인증 실패를 알림
-            // 이 예외는 Spring Security의 ExceptionTranslationFilter에 의해 처리되어
-            // 설정된 JwtAuthenticationEntryPoint의 commence 메소드를 호출하게 됨
-            throw new BadCredentialsException("유효하지 않은 토큰입니다.", e); // 수정된 부분: BadCredentialsException 던지기
-//            이 BadCredentialsException은 필터 밖으로 전파됩니다.
-//            중요: 필터 내에서 이 예외를 잡아서 다른 처리를 하면 안 됩니다. 예외가 Spring Security의 기본 필터 체인으로 넘어가야 합니다.
-//            Spring Security의 ExceptionTranslationFilter가 이 AuthenticationException을 감지합니다.(BadCredentialsException은 AuthenticationException의 하위 클래스)
-//            ExceptionTranslationFilter는 설정된 AuthenticationEntryPoint (즉, 사용자가 만든 JwtAuthenticationEntryPoint)의 commence 메소드를 호출합니다.
-//            JwtAuthenticationEntryPoint.commence() 메소드가 실행되어 response.sendError(HttpServletResponse.SC_UNAUTHORIZED)를 통해 클라이언트에게 401 에러를 반환합니다.
+        } catch (ExpiredJwtException | JwtException | IllegalArgumentException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
close #201 

### 📝 작업 내용
- JWT 유효성 검사 로직 수정
- `TokenAuthenticationFilter` 상의 유효성 검사 및 예외 발생 로직 수정

### 📷 스크린샷 (선택)
- 만료된 토큰 사용 시, 401 응답을 반환합니다.
![스크린샷 2025-04-24 오후 11 37 40](https://github.com/user-attachments/assets/4b3bdd25-5655-4fe4-9ab9-5c1124582097)

- 아예 토큰을 첨부하지 않은 경우에도 401 응답을 반환합니다.
![스크린샷 2025-04-24 오후 11 39 36](https://github.com/user-attachments/assets/a47358f2-633a-4868-93f5-038115976475)


### 💬 리뷰 요구사항 (선택)
- 코드 바뀐 부분 인지만 해주시면 됩니닷
