### PR TITLE
채팅 조회 API가 로그인한 회원 정보를 가져오지 못하는 오류 수정

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
@@ -1,8 +1,8 @@
 package com.gobongbob.festamate.domain.chat.presentation;
 
+import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.chat.dto.request.MessageRequest;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
-import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,15 +39,16 @@ public interface ChatApi {
             MessageRequest request
     );
 
+    // 메시지 조회
     @Operation(summary = "메시지 조회", description = "모임방의 메시지 목록을 페이징하여 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
             @ApiResponse(responseCode = "400", description = "모임방이 존재하지 않습니다.")
     })
-    @GetMapping("/api/messages/room/{roomId}")
+    @GetMapping("/api/messages/chatRooms/{chatRoomId}")
     SuccessResponse<Slice<MessageResponse>> findMessages(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @Parameter(name = "roomId", description = "모임방 ID")
             @PathVariable("roomId") Long roomId,
             @Parameter(description = "페이징 정보")

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -42,12 +42,15 @@ public class ChatController implements ChatApi {
     @Override
     @GetMapping("/api/messages/chatRooms/{chatRoomId}")
     public SuccessResponse<Slice<MessageResponse>> findMessages(
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
             @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Slice<MessageResponse> messages = chatService.findMessagesByRoomId(member.getId(), chatRoomId,
-                pageable);
+        Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
+                memberDetails.getMember().getId(),
+                chatRoomId,
+                pageable
+        );
 
         return new SuccessResponse<>(messages);
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #224 

### 📝 작업 내용
- 채팅 조회 API가 로그인한 회원 정보를 가져오지 못하는 오류 수정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

