### PR TITLE
채팅 조회 응답 DTO의 전송 날짜가 JSON 포맷으로 표시되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/MessageResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/MessageResponse.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.domain.chat.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.chat.domain.Message;
 import java.time.LocalDateTime;
 
@@ -7,6 +8,7 @@ public record MessageResponse(
         Long id,
         String nickname,
         String message,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime sendDate
 ) {
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #230 

### 📝 작업 내용
- 채팅 조회 응답 DTO의 전송 날짜가 JSON 포맷으로 표시되지 않는 오류 수정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

