### PR TITLE
액세스 토큰 만료 테스트

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/TokenType.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/TokenType.java
@@ -3,7 +3,7 @@ package com.gobongbob.festamate.domain.auth.jwt.domain;
 import java.time.Duration;
 
 public enum TokenType {
-    FINAL_ACCESS("final_access", Duration.ofHours(2), false, false),
+    FINAL_ACCESS("final_access", Duration.ofMinutes(2), false, false),
     FINAL_REFRESH("final_refresh", Duration.ofDays(7), false, false),
     ADMIN_ACCESS("admin_access", Duration.ofDays(100), true, false),
     ADMIN_REFRESH("admin_refresh", Duration.ofDays(100), true, false),


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#236 

### 📝 작업 내용
액세스 토큰 만료 테스트를 위해 만료 시간을 2시간 -> 2분으로 변경

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

