### PR TITLE
리프레시 토큰 쿠키 SameSite=None 설정 적용 (Cross-origin)

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -52,7 +52,7 @@ public class TokenController {
                     .secure(true)           // HTTPS 환경에서만 전송 (로컬 HTTP 테스트 시 임시 주석 처리 고려)
                     .path("/")              // 전체 경로에서 쿠키 사용 가능
                     .maxAge(Duration.ofDays(14)) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
-                    .sameSite("Strict")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
+                    .sameSite("None")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
                     .build();
 
             // 4. 응답 반환 (200 OK + 새 액세스 토큰 + 새 쿠키)

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -100,7 +100,7 @@ public class OauthController {
                 .secure(true)           // HTTPS 환경에서만 전송 (로컬 HTTP 테스트 시 임시 주석 처리 고려)
                 .path("/")              // 전체 경로에서 쿠키 사용 가능
                 .maxAge(Duration.ofDays(14)) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
-                .sameSite("Strict")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
+                .sameSite("None")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
                 .build();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
@@ -137,7 +137,8 @@ public class SecurityConfig {
                 "Content-Type",
                 "Authorization",
                 "X-XSRF-token",
-                "Accept"
+                "Accept",
+                "Cookie"
         ));
 
         // 인증 정보 포함 여부

--- a/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gobongbob/festamate/global/util/TokenAuthenticationFilter.java
@@ -37,6 +37,12 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 리프레시 요청은 필터 건너뛰기
+        if (request.getServletPath().equals("/api/auth/refresh")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // 토큰 꺼내기
         String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
         // 가져온 값에서 접두사 제거

--- a/src/main/java/com/gobongbob/festamate/testUser/TestController.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestController.java
@@ -48,7 +48,7 @@ public class TestController {
                 .secure(true) // 로컬 HTTP 테스트 시 임시 주석 처리 고려
                 .path("/")
                 .maxAge(Duration.ofDays(14))
-                .sameSite("Strict")
+                .sameSite("None")
                 .build();
     }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#236 

### 📝 작업 내용
- 모든 리프레시 토큰 쿠키 생성 시 SameSite 속성을 'None'으로 설정
- SameSite=None 사용을 위해 Secure 속성을 'true'로 강제
- CORS 설정에서 'Cookie' 헤더를 허용하도록 확인 (SecurityConfig)
- TokenAuthenticationFilter에서 '/api/auth/refresh' 경로 제외 확인

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

