### PR TITLE
리프레시 토큰 유효 기간 연장

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/TokenType.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/domain/TokenType.java
@@ -3,12 +3,12 @@ package com.gobongbob.festamate.domain.auth.jwt.domain;
 import java.time.Duration;
 
 public enum TokenType {
-    FINAL_ACCESS("final_access", Duration.ofHours(2), false, false),
-    FINAL_REFRESH("final_refresh", Duration.ofDays(7), false, false),
+    FINAL_ACCESS("final_access", Duration.ofHours(2), false, false), // 2시간
+    FINAL_REFRESH("final_refresh", Duration.ofDays(180), false, false), // 6개월(180일)
     ADMIN_ACCESS("admin_access", Duration.ofDays(100), true, false),
     ADMIN_REFRESH("admin_refresh", Duration.ofDays(100), true, false),
     TEST_ACCESS("test_access", Duration.ofDays(100), false, true),
-    TEST_REFRESH("test_refresh", Duration.ofDays(100), false, true);
+    TEST_REFRESH("test_refresh", Duration.ofDays(100), false, true); // 100일
 
     private final String type;
     private final Duration duration;

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -46,12 +46,13 @@ public class TokenController {
                     refreshTokenCookie);
 
             // 3. 성공 시: 새 리프레시 토큰 HttpOnly 쿠키 설정
+            Duration refreshTokenValidity = Duration.ofDays(180); // 6개월(180일)
             ResponseCookie newRefreshTokenCookie = ResponseCookie.from("refreshToken",
                             result.getRefreshToken()) // 서비스로부터 받은 새 리프레시 토큰 값 사용
                     .httpOnly(true)          // JavaScript 접근 불가
                     .secure(true)           // HTTPS 환경에서만 전송 (로컬 HTTP 테스트 시 임시 주석 처리 고려)
                     .path("/")              // 전체 경로에서 쿠키 사용 가능
-                    .maxAge(Duration.ofDays(14)) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
+                    .maxAge(refreshTokenValidity) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
                     .sameSite("None")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
                     .build();
 

--- a/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/jwt/presentation/TokenController.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.auth.jwt.presentation;
 
 import com.gobongbob.festamate.domain.auth.jwt.application.TokenService;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
+import com.gobongbob.festamate.domain.auth.jwt.domain.TokenType;
 import com.gobongbob.festamate.domain.auth.oauth.dto.response.AuthResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
@@ -46,7 +47,7 @@ public class TokenController {
                     refreshTokenCookie);
 
             // 3. 성공 시: 새 리프레시 토큰 HttpOnly 쿠키 설정
-            Duration refreshTokenValidity = Duration.ofDays(180); // 6개월(180일)
+            Duration refreshTokenValidity = TokenType.FINAL_REFRESH.getDuration(); // 6개월(180일)
             ResponseCookie newRefreshTokenCookie = ResponseCookie.from("refreshToken",
                             result.getRefreshToken()) // 서비스로부터 받은 새 리프레시 토큰 값 사용
                     .httpOnly(true)          // JavaScript 접근 불가

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -95,7 +95,7 @@ public class OauthController {
     }
 
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        Duration refreshTokenValidity = Duration.ofDays(180); // 6개월(180일)
+        Duration refreshTokenValidity = TokenType.FINAL_REFRESH.getDuration(); // 6개월(180일)
 
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)          // JavaScript 접근 불가

--- a/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/auth/oauth/presentation/OauthController.java
@@ -95,11 +95,13 @@ public class OauthController {
     }
 
     private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        Duration refreshTokenValidity = Duration.ofDays(180); // 6개월(180일)
+
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)          // JavaScript 접근 불가
                 .secure(true)           // HTTPS 환경에서만 전송 (로컬 HTTP 테스트 시 임시 주석 처리 고려)
                 .path("/")              // 전체 경로에서 쿠키 사용 가능
-                .maxAge(Duration.ofDays(14)) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
+                .maxAge(refreshTokenValidity) // 쿠키 만료 시간 (Redis TTL과 일치 권장)
                 .sameSite("None")      // 동일 출처 요청에만 쿠키 전송 (CSRF 방지)
                 .build();
     }

--- a/src/main/java/com/gobongbob/festamate/testUser/TestController.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestController.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.testUser;
 
+import com.gobongbob.festamate.domain.auth.jwt.domain.TokenType;
 import com.gobongbob.festamate.domain.auth.oauth.dto.response.AuthResponse;
 import com.gobongbob.festamate.global.response.SuccessResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,7 +34,7 @@ public class TestController {
         String refreshToken = tokens.get("refreshToken");
 
         // 3. 리프레시 토큰 HttpOnly 쿠키 설정
-        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(refreshToken);
+        ResponseCookie refreshTokenCookie = createTestRefreshTokenCookie(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         // 4. 본문에는 액세스 토큰만 포함하는 DTO 반환 (TestTokens 사용 안 함)
@@ -42,12 +43,13 @@ public class TestController {
     }
 
     // 쿠키 생성 유틸리티 메서드
-    private ResponseCookie createRefreshTokenCookie(String refreshToken) {
+    private ResponseCookie createTestRefreshTokenCookie(String refreshToken) {
+        Duration testRefreshTokenValidity = TokenType.TEST_REFRESH.getDuration(); // 100일
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true) // 로컬 HTTP 테스트 시 임시 주석 처리 고려
                 .path("/")
-                .maxAge(Duration.ofDays(14))
+                .maxAge(testRefreshTokenValidity)
                 .sameSite("None")
                 .build();
     }

--- a/src/main/java/com/gobongbob/festamate/testUser/TestController.java
+++ b/src/main/java/com/gobongbob/festamate/testUser/TestController.java
@@ -53,12 +53,4 @@ public class TestController {
                 .sameSite("None")
                 .build();
     }
-
-//    테스트 관리자 비활성화 
-//    @PostMapping("/create-admin")
-//    public ResponseEntity<TestService.TestTokens> createAdminMember() {
-//        // 테스트 관리자용 유저 생성 및 JWT 토큰 반환
-//        TestService.TestTokens adminTokens = testService.createAdminMember();
-//        return ResponseEntity.ok(adminTokens);
-//    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#260 

### 📝 작업 내용
- 액세스 토큰은 2시간, 리프레시 토큰은 6개월로 유효 기간을 설정합니다.
- 리프레시 토큰과 Redis TTL 유효 기간을 통일시킵니다.
- 리프레시 쿠키 만료 시간을 TokenType enum 값 참조하도록 수정합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

