### PR TITLE
비효율적인 엔티티 간 연관관계 개선

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
@@ -16,7 +16,11 @@ public class ChatRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String title;
+
+    private String lastMessageContent;
+
+    private LocalDateTime lastMessageTime;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")

--- a/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
@@ -1,18 +1,9 @@
 package com.gobongbob.festamate.domain.chat.domain;
 
 import com.gobongbob.festamate.domain.room.domain.Room;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Getter
@@ -30,4 +21,19 @@ public class ChatRoom {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;
+
+    public static ChatRoom createChatRoom(String title, Room room) {
+        ChatRoom chatRoom = ChatRoom.builder()
+                .title(title)
+                .build();
+        chatRoom.setRoom(room);
+
+        return chatRoom;
+    }
+
+    // 연관관계 편의 메서드
+    public void setRoom(Room room) {
+        this.room = room;
+        room.setChatRoom(this);
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/domain/ChatRoom.java
@@ -40,4 +40,13 @@ public class ChatRoom {
         this.room = room;
         room.setChatRoom(this);
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateLastMessage(String content) {
+        this.lastMessageContent = content;
+        this.lastMessageTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/domain/Message.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/domain/Message.java
@@ -41,7 +41,8 @@ public class Message {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime sendDate;
+    @Builder.Default
+    private LocalDateTime sendDate = LocalDateTime.now();
 
     @Builder
     public Message(ChatRoom chatRoom, Member sender, String message) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -38,8 +38,7 @@ public class RoomParticipationService {
     @Transactional
     @CheckActiveUser
     public ChatRoom participate(Long memberId, Long roomId, FriendPhoneNumbersRequest request) {
-        Member member = memberRepository.findById(
-                        memberId) // 티켓 소모를 위해 영속성 컨텍스트에서 관리하는 member 객체를 재조회
+        Member member = memberRepository.findById(memberId) // 티켓 소모를 위해 영속성 컨텍스트에서 관리하는 member 객체를 재조회
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
@@ -99,8 +98,7 @@ public class RoomParticipationService {
 
     private void participateRoom(Member member, Room room) {
         member.useTicket();
-        RoomParticipant roomParticipant = RoomParticipant.createParticipant(room, member,
-                ParticipantRole.GUEST);
+        RoomParticipant roomParticipant = RoomParticipant.createParticipant(room, member, ParticipantRole.GUEST);
         roomParticipantRepository.save(roomParticipant);
     }
 

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -51,8 +51,7 @@ public class RoomParticipationService {
             room.updateStatus(Status.MATCHED);
         }
 
-        return chatRoomRepository.findByRoom(room)
-                .orElseThrow(() -> new BadRequestException(CHAT_ROOM_NOT_FOUND));
+        return room.getChatRoom();
     }
 
     // 모임방 나가기
@@ -69,12 +68,10 @@ public class RoomParticipationService {
         }
         if (member.isHost(room)) { // 방장이 방을 나가면 방을 삭제
             messageRepository.deleteByRoomId(roomId);
-            chatRoomRepository.deleteByRoomId(roomId);
             roomRepository.delete(room);
         }
 
-        return chatRoomRepository.findByRoom(room)
-                .orElseThrow(() -> new BadRequestException(CHAT_ROOM_NOT_FOUND));
+        return room.getChatRoom();
     }
 
     // 방장 여부 확인

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -48,7 +48,7 @@ public class RoomParticipationService {
         validateParticipation(room, participants);
 
         participants.forEach(participant -> participateRoom(participant, room));
-        if (roomParticipantRepository.countByRoom_Id(roomId) == room.getMaxParticipants()) { // 방에 참여자가 다 찼을 때
+        if (room.isFull()) { // 방에 참여자가 다 찼을 때
             room.updateStatus(Status.MATCHED);
         }
 
@@ -65,11 +65,9 @@ public class RoomParticipationService {
         validateNotHost(room, member);
         validateRoomMatching(room);
 
-        List<RoomParticipant> guestParticipants = roomParticipantRepository.findByRoomAndRole(
-                roomId,
-                ParticipantRole.GUEST);
-        roomParticipantRepository.deleteAll(guestParticipants);
-
+        if (!member.isHost(room)) { // 참가자 측이 방을 나가면 참가자만 삭제
+            room.getParticipants().removeIf(participant -> participant.getParticipantRole() == ParticipantRole.GUEST);
+        }
         if (member.isHost(room)) { // 방장이 방을 나가면 방을 삭제
             messageRepository.deleteByRoomId(roomId);
             chatRoomRepository.deleteByRoomId(roomId);
@@ -83,6 +81,7 @@ public class RoomParticipationService {
     // 방장 여부 확인
     @CheckActiveUser
     public IsMemberHostResponse isMemberHost(Long roomId, Member member) {
+
         boolean isHost = roomParticipantRepository.findByRoom_IdAndMember_Id(roomId, member.getId())
                 .orElseThrow(() -> new BadRequestException(NO_PARTICIPATING_ROOM))
                 .isHost();
@@ -119,7 +118,7 @@ public class RoomParticipationService {
     private void validateParticipation(Room room, List<Member> participants) {
         validateRoomMatching(room); // 현재 매칭중인 방인지 확인
         validateRoomFull(room); // 방에 참여자가 다 찼는지 확인
-        validateRoomJoinable(room, participants.size()); // 방에 참여할 수 있는 인원인지 확인
+        validateRoomJoinable(room); // 방에 참여할 수 있는 인원인지 확인
         validatePhoneNumberUnique(participants); // 참여자 간의 전화번호가 중복되지 않는지 확인
         validateGender(room, participants); // 방의 성별과 참여자의 성별이 일치하는지 확인
     }
@@ -131,13 +130,13 @@ public class RoomParticipationService {
     }
 
     private void validateRoomFull(Room room) {
-        if (roomParticipantRepository.countByRoom_Id(room.getId()) >= (room.getMaxParticipants() / 2)) {
+        if (room.isFull()) {
             throw new BadRequestException(ROOM_FULL);
         }
     }
 
-    private void validateRoomJoinable(Room room, int participants) {
-        if (participants != (room.getMaxParticipants() / 2)) { // 모임의 남은 자리 수와 참여하려는 인원의 수가 맞는지
+    private void validateRoomJoinable(Room room) {
+        if (!room.isJoinable()) { // 모임의 남은 자리 수와 참여하려는 인원의 수가 맞는지
             throw new BadRequestException(ROOM_NOT_JOINABLE);
         }
     }

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -102,7 +102,6 @@ public class RoomService {
         return roomRepository.findById(roomId)
                 .map(room -> RoomResponse.fromEntity(
                         room,
-                        roomParticipantRepository.countByRoom_Id(room.getId()),
                         findRoomAuthorityByMember(room, memberDetails),
                         roomParticipantRepository.findByRoomAndRole(room.getId(),
                                 ParticipantRole.HOST),
@@ -152,7 +151,6 @@ public class RoomService {
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);
 
-        roomParticipantRepository.deleteByRoomId(roomId);
         messageRepository.deleteByRoomId(roomId);
         chatRoomRepository.deleteByRoomId(roomId);
         roomRepository.delete(room);
@@ -167,12 +165,11 @@ public class RoomService {
             return RoomAuthority.NON_MEMBER;
         }
 
-        return roomParticipantRepository.findByRoom_IdAndMember_Id(room.getId(),
-                        memberDetails.getMember().getId())
+        return room.getParticipants()
                 .stream()
+                .filter(participant -> participant.getMember().getId().equals(memberDetails.getMember().getId()))
                 .findFirst()
-                .map(participant -> participant.isHost() ? RoomAuthority.HOST
-                        : RoomAuthority.PARTICIPANT)
+                .map(participant -> participant.isHost() ? RoomAuthority.HOST : RoomAuthority.PARTICIPANT)
                 .orElse(RoomAuthority.NON_PARTICIPANT);
     }
 
@@ -203,8 +200,7 @@ public class RoomService {
     }
 
     private void validateAlone(Room room) {
-        int participantsCount = roomParticipantRepository.countByRoom_Id(room.getId());
-        if (participantsCount > 1) {
+        if (!room.isJoinable()) { // 호스트 측 참가자만 있는 경우
             throw new BadRequestException(CAN_NOT_UPDATE);
         }
     }

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -54,24 +54,9 @@ public class RoomService {
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
 
         Room createdRoom = roomRepository.save(request.toEntity(member));
+        uploadImageIfExist(imageFiles, createdRoom);
 
-        if (imageFiles != null && !imageFiles.isEmpty()) {
-            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
-                    .stream()
-                    .map(RoomImage::fromEntity)
-                    .toList();
-            createdRoom.assignImages(roomImages);
-        }
-        if (imageFiles == null || imageFiles.isEmpty()) {
-            Image image = pickRandomImage();
-            RoomImage roomImage = RoomImage.fromEntity(image);
-            createdRoom.assignImages(List.of(roomImage));
-        }
-
-        ChatRoom chatRoom = ChatRoom.builder()
-                .name(createdRoom.getTitle())
-                .room(createdRoom)
-                .build();
+        ChatRoom chatRoom = ChatRoom.createChatRoom(createdRoom.getTitle(), createdRoom);
         chatRoomRepository.save(chatRoom);
 
         RoomParticipant roomParticipant = RoomParticipant.createHost(createdRoom, member);
@@ -137,6 +122,7 @@ public class RoomService {
                 request.meetingDateTime(),
                 request.maxParticipants()
         );
+        room.getChatRoom().updateTitle(request.title());
     }
 
     // 방 삭제(일반, admin)
@@ -148,7 +134,6 @@ public class RoomService {
         validateIsHost(room, member);
 
         messageRepository.deleteByRoomId(roomId);
-        chatRoomRepository.deleteByRoomId(roomId);
         roomRepository.delete(room);
 
         /*
@@ -167,6 +152,21 @@ public class RoomService {
                 .findFirst()
                 .map(participant -> participant.isHost() ? RoomAuthority.HOST : RoomAuthority.PARTICIPANT)
                 .orElse(RoomAuthority.NON_PARTICIPANT);
+    }
+
+    private void uploadImageIfExist(List<MultipartFile> imageFiles, Room createdRoom) {
+        if (imageFiles != null && !imageFiles.isEmpty()) {
+            List<RoomImage> roomImages = imageService.uploadImages(imageFiles)
+                    .stream()
+                    .map(RoomImage::fromEntity)
+                    .toList();
+            createdRoom.assignImages(roomImages);
+        }
+        if (imageFiles == null || imageFiles.isEmpty()) {
+            Image image = pickRandomImage();
+            RoomImage roomImage = RoomImage.fromEntity(image);
+            createdRoom.assignImages(List.of(roomImage));
+        }
     }
 
     private Image pickRandomImage() {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -85,10 +85,7 @@ public class RoomService {
     public Slice<RoomListResponse> findBySearchCondition(Pageable pageable,
             FilteringCondition filteringCondition) {
         return roomRepository.findBySearchCondition(pageable, filteringCondition)
-                .map(room -> RoomListResponse.fromEntity(
-                        room,
-                        roomParticipantRepository.countByRoom_Id(room.getId())
-                ));
+                .map(RoomListResponse::fromEntity);
     }
 
     // 참여 중인 모임방 조회
@@ -96,10 +93,9 @@ public class RoomService {
     public List<RoomListResponse> findParticipatingRooms(Long memberId) {
         return roomParticipantRepository.findByMember_Id(memberId)
                 .stream()
-                .map(roomParticipant -> RoomListResponse.fromEntity(
-                        roomParticipant.getRoom(),
-                        roomParticipantRepository.countByRoom_Id(roomParticipant.getRoom().getId())
-                )).toList();
+                .map(RoomParticipant::getRoom)
+                .map(RoomListResponse::fromEntity)
+                .toList();
     }
 
     public RoomResponse findRoomById(CustomMemberDetails memberDetails, Long roomId) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomService.java
@@ -82,8 +82,7 @@ public class RoomService {
     }
 
     // 방 전체 조회
-    public Slice<RoomListResponse> findBySearchCondition(Pageable pageable,
-            FilteringCondition filteringCondition) {
+    public Slice<RoomListResponse> findBySearchCondition(Pageable pageable, FilteringCondition filteringCondition) {
         return roomRepository.findBySearchCondition(pageable, filteringCondition)
                 .map(RoomListResponse::fromEntity);
     }
@@ -103,18 +102,15 @@ public class RoomService {
                 .map(room -> RoomResponse.fromEntity(
                         room,
                         findRoomAuthorityByMember(room, memberDetails),
-                        roomParticipantRepository.findByRoomAndRole(room.getId(),
-                                ParticipantRole.HOST),
-                        roomParticipantRepository.findByRoomAndRole(room.getId(),
-                                ParticipantRole.GUEST)
+                        roomParticipantRepository.findByRoomAndRole(room.getId(), ParticipantRole.HOST),
+                        roomParticipantRepository.findByRoomAndRole(room.getId(), ParticipantRole.GUEST)
                 )).orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
     }
 
     // 모임방 정보 수정
     @Transactional
     @CheckActiveUser
-    public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request,
-            List<MultipartFile> imageFiles) {
+    public void updateRoomById(Member member, Long roomId, RoomUpdateRequest request, List<MultipartFile> imageFiles) {
         Room room = roomRepository.findByIdWithHost(roomId)
                 .orElseThrow(() -> new BadRequestException(NOT_FOUND_ROOM));
         validateIsHost(room, member);

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -82,4 +82,12 @@ public class Room {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    public boolean isFull() {
+        return participants.size() == maxParticipants;
+    }
+
+    public boolean isJoinable() {
+        return participants.size() == (maxParticipants / 2);
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -47,6 +47,10 @@ public class Room {
 
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
+    private List<RoomParticipant> participants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<RoomImage> images = new ArrayList<>();
 
     // 연관관계 편의 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -1,5 +1,6 @@
 package com.gobongbob.festamate.domain.room.domain;
 
+import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.image.domain.RoomImage;
 import com.gobongbob.festamate.domain.member.domain.Gender;
 import com.gobongbob.festamate.domain.member.domain.Member;
@@ -52,6 +53,10 @@ public class Room {
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<RoomImage> images = new ArrayList<>();
+
+    @OneToOne(mappedBy = "room", cascade = CascadeType.ALL)
+    @Setter
+    private ChatRoom chatRoom;
 
     // 연관관계 편의 메서드
     public void assignImages(List<RoomImage> roomImages) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
@@ -29,21 +29,26 @@ public class RoomParticipant {
     private boolean isHost;
 
     public static RoomParticipant createHost(Room room, Member member) {
-        return RoomParticipant.builder()
-                .room(room)
+        RoomParticipant roomParticipant = RoomParticipant.builder()
                 .member(member)
                 .participantRole(ParticipantRole.HOST)
                 .isHost(true)
                 .build();
+        roomParticipant.setRoom(room);
+
+        return roomParticipant;
     }
 
     public static RoomParticipant createParticipant(Room room, Member member, ParticipantRole participantRole) {
-        return RoomParticipant.builder()
+        RoomParticipant roomParticipant = RoomParticipant.builder()
                 .room(room)
                 .member(member)
                 .participantRole(participantRole)
                 .isHost(false)
                 .build();
+        roomParticipant.setRoom(room);
+
+        return roomParticipant;
     }
 
     // 연관관계 편의 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
@@ -45,4 +45,10 @@ public class RoomParticipant {
                 .isHost(false)
                 .build();
     }
+
+    // 연관관계 편의 메서드
+    public void setRoom(Room room) {
+        this.room = room;
+        room.getParticipants().add(this);
+    }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomListResponse.java
@@ -24,7 +24,7 @@ public record RoomListResponse(
         ImageResponse thumbnail
 ) {
 
-    public static RoomListResponse fromEntity(Room room, int currentParticipants) {
+    public static RoomListResponse fromEntity(Room room) {
         Image thumbnail = room.getImages().get(0).getImage();
 
         return new RoomListResponse(
@@ -38,7 +38,7 @@ public record RoomListResponse(
                 room.getPreferredStudentIdMax(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
-                currentParticipants,
+                room.getParticipants().size(),
                 ImageResponse.fromEntity(thumbnail)
         );
     }

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -32,7 +32,6 @@ public record RoomResponse(
 
     public static RoomResponse fromEntity(
             Room room,
-            int currentParticipants,
             RoomAuthority roomAuthority,
             List<RoomParticipant> hostParticipants,
             List<RoomParticipant> guestParticipants
@@ -48,7 +47,7 @@ public record RoomResponse(
                 room.getPreferredStudentIdMax(),
                 room.getMeetingDateTime(),
                 room.getMaxParticipants(),
-                currentParticipants,
+                room.getParticipants().size(),
                 roomAuthority,
                 toParticipantResponse(hostParticipants),
                 toParticipantResponse(guestParticipants),
@@ -58,7 +57,7 @@ public record RoomResponse(
 
     private static List<ParticipantResponse> toParticipantResponse(List<RoomParticipant> participants) {
         return participants.stream()
-                .map(participant -> ParticipantResponse.fromEntity(participant, participant.isHost()))
+                .map(ParticipantResponse::fromEntity)
                 .toList();
     }
 
@@ -79,7 +78,7 @@ public record RoomResponse(
             String profileImageUrl
     ) {
 
-        private static ParticipantResponse fromEntity(RoomParticipant participant, boolean isHost) {
+        private static ParticipantResponse fromEntity(RoomParticipant participant) {
             Member member = participant.getMember();
 
             return new ParticipantResponse(
@@ -88,7 +87,7 @@ public record RoomResponse(
                     member.getStudentId().substring(2, 4),
                     member.getGender().name(),
                     member.getStudentDepartment(),
-                    isHost,
+                    participant.isHost(),
                     member.getProfileImage().getUrl()
             );
         }

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomParticipantRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomParticipantRepository.java
@@ -5,9 +5,7 @@ import com.gobongbob.festamate.domain.room.domain.RoomParticipant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface RoomParticipantRepository extends JpaRepository<RoomParticipant, Long> {
 
@@ -18,15 +16,6 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
     Optional<RoomParticipant> findById(Long id);
 
     void delete(RoomParticipant roomParticipant);
-
-    void deleteByMember_Id(Long memberId);
-
-    @Transactional
-    @Modifying
-    @Query("delete from RoomParticipant r where r.room.id = ?1")
-    void deleteByRoomId(Long id);
-
-    List<RoomParticipant> findByRoom_Id(Long roomId);
 
     @Query("""
             SELECT DISTINCT p FROM RoomParticipant p
@@ -39,6 +28,4 @@ public interface RoomParticipantRepository extends JpaRepository<RoomParticipant
     List<RoomParticipant> findByMember_Id(Long memberId);
 
     Optional<RoomParticipant> findByRoom_IdAndMember_Id(Long roomId, Long memberId);
-
-    int countByRoom_Id(Long roomId);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -58,7 +58,7 @@ public class RoomController implements RoomApi {
         chatService.sendMessage(
                 createdChatRoom.getId(),
                 memberDetails.getMember(),
-                "안녕하세요! " + createdChatRoom.getName() + "에 오신 것을 환영합니다!"
+                "안녕하세요! " + createdChatRoom.getTitle() + "에 오신 것을 환영합니다!"
         );
 
         return new SuccessResponse<>();


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #221 

### 📝 작업 내용
#### 코드 변경 내용
- `Room` 엔티티에 `Participant` 엔티티와의 OneToMany 매핑 추가
- `Room` 엔티티에 `ChatRoom` 엔티티와의 OneToOne 매핑 추가

#### 연관관계를 수정하게 된 이유
- 처음에는 기본적으로 신경쓸 부분이 적은 단방향 연관관계를 택했는데, 아무래도 구현하다보니 비즈니스 로직이 너무 복잡해져서 로직을 편리하게 짜기 위해 연관관계를 다시 바꾸게 됐습니다.
- 서비스 특성상 모임을 통해 참가자나 채팅방을 조회해야 할 일이 굉장히 많은데, 이전까지는 Room 엔티티에 이에 대한 직접적인 정보가 없다보니 `room.getParticipants()` 등으로 조회하지 못하고 매번 DB를 통해 따로 조회해야 했습니다. 이번 개선을 통해 이러한 문제를 해결했습니다.

#### 성능 관련 이슈
- 이번 수정을 기점으로 Room 객체를 조회하게 되면 항상 그에 딸린 `List<Participant> participants`, `ChatRoom room` 등이 함께 조회되게 됩니다. 만약 `Room`에 대한 정보만 필요한 경우가 많다면, 이는 비효율적입니다.
- 하지만 참여자 정보(현재 참여자 머릿수), 채팅방 정보(채팅방 id) 등이 이미 대부분의 API에서 Room과 함꼐 제공되는 상황이기 때문에, 큰 상관이 없다고 생각하고 있습니다.

#### 비즈니스 로직 간소화
- 앞에서 언급했듯, 따로 DB에서 조인 쿼리를 통해 조회해야 하는 부분들을 모두 객체 레벨에서 조회할 수 있게 됐습니다.
- 예를 들면 다음과 같이 Repository를 통해 조회해야 했던 부분을 객체 자체적으로 해결할 수 있게 바꿨습니다.
```java
// Before
if (roomParticipantRepository.countByRoom_Id(roomId) == room.getMaxParticipants()) {
        room.updateStatus(Status.MATCHED);
}

// After
if (room.isFull()) {
        room.updateStatus(Status.MATCHED);
}

public boolean isFull() {
        return participants.size() == maxParticipants;
}
```
- Cascade 설정을 활용한 삭제 로직이 깔끔하게 바뀌었습니다. 그런데 저희가 추후에 "완전 삭제"가 아닌 "Soft Delete" 방식을 적용할거라... 완전 삭제되지 않도록 이 부분은 추후 수정해야할 것 같습니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
Room 엔티티에 추가된 연관관계만 중점적으로 봐주시면 될 것 같습니다.
