### PR TITLE
참여중인 채팅방 조회 기능 구현

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
@@ -5,14 +5,17 @@ import static com.gobongbob.festamate.global.response.ResponseCode.NO_AUTHORITY_
 
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
 import com.gobongbob.festamate.domain.chat.domain.Message;
+import com.gobongbob.festamate.domain.chat.dto.response.ChatRoomListResponse;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
 import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
+import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.persistence.RoomParticipantRepository;
+import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
-import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -27,6 +30,7 @@ public class ChatService {
 
     private final MessageRepository messageRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final RoomRepository roomRepository;
     private final RoomParticipantRepository roomParticipantRepository;
     private final SimpMessageSendingOperations messagingTemplate;
 
@@ -40,7 +44,6 @@ public class ChatService {
                         .chatRoom(chatRoom)
                         .sender(member)
                         .message(message)
-                        .sendDate(LocalDateTime.now())
                         .build()
         );
         MessageResponse response = MessageResponse.fromEntity(savedMessage);
@@ -50,8 +53,7 @@ public class ChatService {
 
     // 메시지 조회
     @CheckActiveUser
-    public Slice<MessageResponse> findMessagesByRoomId(Long memberId, Long roomId,
-            Pageable pageable) {
+    public Slice<MessageResponse> findMessagesByRoomId(Long memberId, Long roomId, Pageable pageable) {
 //        validateRoomParticipation(memberId, roomId);
 
         return messageRepository.findByRoomId(roomId, pageable)
@@ -62,5 +64,13 @@ public class ChatService {
         if (roomParticipantRepository.findByRoom_IdAndMember_Id(memberId, roomId).isEmpty()) {
             throw new BadRequestException(NO_AUTHORITY_CHAT_ROOM);
         }
+    }
+
+    public List<ChatRoomListResponse> findParticipatingChatRooms(Member member) {
+        return roomRepository.findRoomsWithChatRoomByMember(member.getId())
+                .stream()
+                .map(Room::getChatRoom)
+                .map(ChatRoomListResponse::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
@@ -10,12 +10,9 @@ import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.domain.chat.persistence.ChatRoomRepository;
 import com.gobongbob.festamate.domain.chat.persistence.MessageRepository;
 import com.gobongbob.festamate.domain.member.domain.Member;
-import com.gobongbob.festamate.domain.room.domain.Room;
 import com.gobongbob.festamate.domain.room.persistence.RoomParticipantRepository;
-import com.gobongbob.festamate.domain.room.persistence.RoomRepository;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -30,7 +27,6 @@ public class ChatService {
 
     private final MessageRepository messageRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final RoomRepository roomRepository;
     private final RoomParticipantRepository roomParticipantRepository;
     private final SimpMessageSendingOperations messagingTemplate;
 
@@ -66,11 +62,8 @@ public class ChatService {
         }
     }
 
-    public List<ChatRoomListResponse> findParticipatingChatRooms(Member member) {
-        return roomRepository.findRoomsWithChatRoomByMember(member.getId())
-                .stream()
-                .map(Room::getChatRoom)
-                .map(ChatRoomListResponse::fromEntity)
-                .toList();
+    public Slice<ChatRoomListResponse> findParticipatingChatRooms(Pageable pageable, Member member) {
+        return chatRoomRepository.findParticipatingChatRooms(pageable, member.getId())
+                .map(ChatRoomListResponse::fromEntity);
     }
 }

--- a/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,22 @@
+package com.gobongbob.festamate.domain.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+
+public record ChatRoomListResponse(
+        Long id,
+        String name,
+        String lastMessageContent,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        String lastMessageTime
+) {
+
+    public static ChatRoomListResponse fromEntity(ChatRoom chatRoom) {
+        return new ChatRoomListResponse(
+                chatRoom.getId(),
+                chatRoom.getTitle(),
+                chatRoom.getLastMessageContent(),
+                chatRoom.getLastMessageTime()
+        );
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/ChatRoomListResponse.java
@@ -2,13 +2,14 @@ package com.gobongbob.festamate.domain.chat.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+import java.time.LocalDateTime;
 
 public record ChatRoomListResponse(
         Long id,
-        String name,
+        String title,
         String lastMessageContent,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        String lastMessageTime
+        LocalDateTime lastMessageTime
 ) {
 
     public static ChatRoomListResponse fromEntity(ChatRoom chatRoom) {

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.gobongbob.festamate.domain.chat.persistence;
+
+import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ChatRoomQueryDslRepository {
+
+    Slice<ChatRoom> findParticipatingChatRooms(Pageable pageable, Long memberId);
+}

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepositoryImpl.java
@@ -1,0 +1,98 @@
+package com.gobongbob.festamate.domain.chat.persistence;
+
+import static com.gobongbob.festamate.domain.chat.domain.QChatRoom.chatRoom;
+import static com.gobongbob.festamate.domain.room.domain.QRoom.room;
+import static com.gobongbob.festamate.domain.room.domain.QRoomParticipant.roomParticipant;
+
+import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomQueryDslRepositoryImpl implements ChatRoomQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 모임 상태, 학과, 학번, 성별에 따른 조회
+     */
+    @Override
+    public Slice<ChatRoom> findParticipatingChatRooms(Pageable pageable, Long memberId) {
+        int pageSize = pageable.getPageSize();
+
+        JPAQuery<ChatRoom> basicQuery = queryFactory
+                .select(chatRoom)
+                .from(roomParticipant)
+                .join(roomParticipant.room, room)
+                .join(room.chatRoom, chatRoom).fetchJoin()
+                .where(roomParticipant.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageSize + 1);
+
+        List<ChatRoom> content = addSortingQuery(basicQuery, pageable.getSort().toString());
+
+        return new SliceImpl<>(content, pageable, hasNextPage(content, pageSize));
+    }
+
+    /**
+     * 마지막 페이지 여부 확인 메소드
+     */
+    private boolean hasNextPage(List<ChatRoom> content, int pageSize) {
+        boolean hasNext = false;
+        if (content.size() > pageSize) {
+            hasNext = true;
+            content.remove(pageSize);
+
+        }
+        return hasNext;
+    }
+
+    /*
+      정렬 관련 쿼리를 추가하기 위한 메소드
+     */
+    // 마지막 메시지 전송 시간이 얼마나 최신이냐에 따라서 정렬
+    private List<ChatRoom> addSortingQuery(JPAQuery<ChatRoom> basicQuery, String sortType) {
+        List<ChatRoom> content;
+
+        switch (sortType) {
+            case "id":
+                content = basicQuery
+                        .orderBy(chatRoom.id.desc())
+                        .fetch();
+                break;
+
+            case "rid":
+                content = basicQuery
+                        .orderBy(chatRoom.id.asc())
+                        .fetch();
+                break;
+
+            case "date":
+                content = basicQuery
+                        .orderBy(chatRoom.lastMessageTime.desc())
+                        .fetch();
+                break;
+
+            case "rdate":
+                content = basicQuery
+                        .orderBy(chatRoom.lastMessageTime.asc())
+                        .fetch();
+                break;
+
+            default:
+                content = basicQuery
+                        .orderBy(chatRoom.id.desc())
+                        .fetch(); // 기본 정렬
+                break;
+        }
+
+        return content;
+    }
+}

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepositoryImpl.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomQueryDslRepositoryImpl.java
@@ -5,6 +5,7 @@ import static com.gobongbob.festamate.domain.room.domain.QRoom.room;
 import static com.gobongbob.festamate.domain.room.domain.QRoomParticipant.roomParticipant;
 
 import com.gobongbob.festamate.domain.chat.domain.ChatRoom;
+import com.gobongbob.festamate.domain.room.domain.Room;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -25,20 +26,21 @@ public class ChatRoomQueryDslRepositoryImpl implements ChatRoomQueryDslRepositor
      */
     @Override
     public Slice<ChatRoom> findParticipatingChatRooms(Pageable pageable, Long memberId) {
-        int pageSize = pageable.getPageSize();
-
-        JPAQuery<ChatRoom> basicQuery = queryFactory
-                .select(chatRoom)
+        JPAQuery<Room> basicQuery = queryFactory
+                .select(room)  // Room을 select
                 .from(roomParticipant)
                 .join(roomParticipant.room, room)
-                .join(room.chatRoom, chatRoom).fetchJoin()
+                .join(room.chatRoom, chatRoom).fetchJoin()  // fetch join
                 .where(roomParticipant.member.id.eq(memberId))
                 .offset(pageable.getOffset())
-                .limit(pageSize + 1);
+                .limit(pageable.getPageSize() + 1);
 
-        List<ChatRoom> content = addSortingQuery(basicQuery, pageable.getSort().toString());
+        List<Room> content = addSortingQuery(basicQuery, pageable.getSort().toString());
+        List<ChatRoom> chatRooms = content.stream()
+                .map(Room::getChatRoom)
+                .toList();
 
-        return new SliceImpl<>(content, pageable, hasNextPage(content, pageSize));
+        return new SliceImpl<>(chatRooms, pageable, hasNextPage(chatRooms, pageable.getPageSize()));
     }
 
     /**
@@ -58,8 +60,8 @@ public class ChatRoomQueryDslRepositoryImpl implements ChatRoomQueryDslRepositor
       정렬 관련 쿼리를 추가하기 위한 메소드
      */
     // 마지막 메시지 전송 시간이 얼마나 최신이냐에 따라서 정렬
-    private List<ChatRoom> addSortingQuery(JPAQuery<ChatRoom> basicQuery, String sortType) {
-        List<ChatRoom> content;
+    private List<Room> addSortingQuery(JPAQuery<Room> basicQuery, String sortType) {
+        List<Room> content;
 
         switch (sortType) {
             case "id":

--- a/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/persistence/ChatRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryDslRepository {
 
     Optional<ChatRoom> findByRoom(Room room);
 

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
@@ -2,6 +2,7 @@ package com.gobongbob.festamate.domain.chat.presentation;
 
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.chat.dto.request.MessageRequest;
+import com.gobongbob.festamate.domain.chat.dto.response.ChatRoomListResponse;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -37,6 +39,17 @@ public interface ChatApi {
             Authentication authentication,
             @Parameter(description = "메시지 전송 요청 정보")
             MessageRequest request
+    );
+
+    @Operation(summary = "참여중인 채팅방 조회", description = "로그인 중인 회원이 참여중인 채팅방을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
+            @ApiResponse(responseCode = "400", description = "모임방이 존재하지 않습니다.")
+    })
+    @GetMapping("/api/chatRooms/participations")
+    SuccessResponse<List<ChatRoomListResponse>> findParticipatingChatRooms(
+            @Parameter(description = "인증된 사용자 정보", hidden = true)
+            @AuthenticationPrincipal CustomMemberDetails memberDetails
     );
 
     // 메시지 조회

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatApi.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -47,9 +46,11 @@ public interface ChatApi {
             @ApiResponse(responseCode = "400", description = "모임방이 존재하지 않습니다.")
     })
     @GetMapping("/api/chatRooms/participations")
-    SuccessResponse<List<ChatRoomListResponse>> findParticipatingChatRooms(
+    SuccessResponse<Slice<ChatRoomListResponse>> findParticipatingChatRooms(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
-            @AuthenticationPrincipal CustomMemberDetails memberDetails
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
+            @Parameter(description = "페이징 정보")
+            @PageableDefault(size = 20, sort = "date", direction = Sort.Direction.DESC) Pageable pageable
     );
 
     // 메시지 조회

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -3,9 +3,11 @@ package com.gobongbob.festamate.domain.chat.presentation;
 import com.gobongbob.festamate.domain.auth.jwt.domain.CustomMemberDetails;
 import com.gobongbob.festamate.domain.chat.application.ChatService;
 import com.gobongbob.festamate.domain.chat.dto.request.MessageRequest;
+import com.gobongbob.festamate.domain.chat.dto.response.ChatRoomListResponse;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.global.response.SuccessResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -36,6 +38,14 @@ public class ChatController implements ChatApi {
         chatService.sendMessage(chatRoomId, member, request.message());
 
         return new SuccessResponse<>();
+    }
+
+    @Override
+    @GetMapping("/api/chatRooms/participations")
+    public SuccessResponse<List<ChatRoomListResponse>> findParticipatingChatRooms(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails
+    ) {
+        return new SuccessResponse<>(chatService.findParticipatingChatRooms(memberDetails.getMember()));
     }
 
     // 메시지 조회

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -7,7 +7,6 @@ import com.gobongbob.festamate.domain.chat.dto.response.ChatRoomListResponse;
 import com.gobongbob.festamate.domain.chat.dto.response.MessageResponse;
 import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.global.response.SuccessResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -42,10 +41,11 @@ public class ChatController implements ChatApi {
 
     @Override
     @GetMapping("/api/chatRooms/participations")
-    public SuccessResponse<List<ChatRoomListResponse>> findParticipatingChatRooms(
-            @AuthenticationPrincipal CustomMemberDetails memberDetails
+    public SuccessResponse<Slice<ChatRoomListResponse>> findParticipatingChatRooms(
+            @AuthenticationPrincipal CustomMemberDetails memberDetails,
+            @PageableDefault(size = 20, sort = "date", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return new SuccessResponse<>(chatService.findParticipatingChatRooms(memberDetails.getMember()));
+        return new SuccessResponse<>(chatService.findParticipatingChatRooms(pageable, memberDetails.getMember()));
     }
 
     // 메시지 조회

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/RoomResponse.java
@@ -25,6 +25,7 @@ public record RoomResponse(
         int maxParticipants,
         int currentParticipants,
         RoomAuthority roomAuthority,
+        Long chatRoomId,
         List<ParticipantResponse> hostParticipants,
         List<ParticipantResponse> guestParticipants,
         List<ImageResponse> images
@@ -49,6 +50,7 @@ public record RoomResponse(
                 room.getMaxParticipants(),
                 room.getParticipants().size(),
                 roomAuthority,
+                room.getChatRoom().getId(),
                 toParticipantResponse(hostParticipants),
                 toParticipantResponse(guestParticipants),
                 toImageResponse(room)

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
@@ -1,6 +1,7 @@
 package com.gobongbob.festamate.domain.room.persistence;
 
 import com.gobongbob.festamate.domain.room.domain.Room;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,4 +20,13 @@ public interface RoomRepository extends Repository<Room, Long>, RoomQueryDslRepo
     Optional<Room> findByIdWithHost(Long id);
 
     void delete(Room room);
+
+    @Query("""
+                SELECT DISTINCT r
+                FROM RoomParticipant rp
+                JOIN rp.room r
+                JOIN FETCH r.chatRoom
+                WHERE rp.member.id = :memberId
+            """)
+    List<Room> findRoomsWithChatRoomByMember(Long memberId);
 }

--- a/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/persistence/RoomRepository.java
@@ -1,7 +1,6 @@
 package com.gobongbob.festamate.domain.room.persistence;
 
 import com.gobongbob.festamate.domain.room.domain.Room;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,13 +19,4 @@ public interface RoomRepository extends Repository<Room, Long>, RoomQueryDslRepo
     Optional<Room> findByIdWithHost(Long id);
 
     void delete(Room room);
-
-    @Query("""
-                SELECT DISTINCT r
-                FROM RoomParticipant rp
-                JOIN rp.room r
-                JOIN FETCH r.chatRoom
-                WHERE rp.member.id = :memberId
-            """)
-    List<Room> findRoomsWithChatRoomByMember(Long memberId);
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #213 

### 📝 작업 내용
- 참여중인 채팅방 조회 기능 구현
  - 최근 대화가 발생한 채팅방을 우선으로 정렬하여 결과를 반환합니다.

### 📷 스크린샷 (선택)
```json
{
    "isSuccess": true,
    "message": "요청에 성공하였습니다.",
    "result": {
        "content": [
            {
                "id": 31,
                "title": "명상 & 마인드풀니스",
                "lastMessageContent": null,
                "lastMessageTime": null
            }
        ],
        "pageable": {
            "pageNumber": 0,
            "pageSize": 20,
            "sort": {
                "empty": false,
                "sorted": true,
                "unsorted": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "size": 20,
        "number": 0,
        "sort": {
            "empty": false,
            "sorted": true,
            "unsorted": false
        },
        "numberOfElements": 1,
        "first": true,
        "last": true,
        "empty": false
    }
}
```

### 💬 리뷰 요구사항 (선택)