### PR TITLE
유저 차단 시 관련 신고 processed 처리 연동

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -19,6 +19,8 @@ import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
 import com.gobongbob.festamate.domain.member.persistence.MemberRepository;
+import com.gobongbob.festamate.domain.report.domain.Report;
+import com.gobongbob.festamate.domain.report.persistence.ReportRepository;
 import com.gobongbob.festamate.domain.room.dto.response.MemberExistResponse;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
@@ -39,6 +41,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final ProfileImageRepository profileImageRepository;
     private final ImageService imageService;
+    private final ReportRepository reportRepository;
 
     @Transactional
     public Member createMember(MemberCreateRequest request) {
@@ -166,6 +169,13 @@ public class MemberService {
                 .orElseThrow(() -> new BadRequestException(NO_MEMBER));
         member.block();
         memberRepository.save(member);
+
+        // 해당 유저가 피신고자인 모든 신고의 processed = true 처리
+        List<Report> reports = reportRepository.findByReportedMember(member);
+        for (Report report : reports) {
+            report.setProcessed(true);
+        }
+        reportRepository.saveAll(reports);
     }
 
     // 유저 제재 해제(admin)

--- a/src/main/java/com/gobongbob/festamate/domain/report/domain/Report.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/domain/Report.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -48,6 +49,7 @@ public class Report {
     @Column(nullable = false)
     private LocalDateTime reportDate;
 
+    @Setter
     @Column
     @Builder.Default
     private Boolean processed = false;

--- a/src/main/java/com/gobongbob/festamate/domain/report/persistence/ReportRepository.java
+++ b/src/main/java/com/gobongbob/festamate/domain/report/persistence/ReportRepository.java
@@ -1,14 +1,19 @@
 package com.gobongbob.festamate.domain.report.persistence;
 
+import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.report.domain.Report;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
     List<Report> findByProcessed(Boolean processed);
+
     List<Report> findByRoomIdAndReporterId(Long roomId, Long reporterId);
+
     List<Report> findByReportedMemberIdAndReporterId(Long reportedMemberId, Long reporterId);
+
+    List<Report> findByReportedMember(Member member);
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#278 

### 📝 작업 내용
유저 차단 시 관련 신고 processed 처리 연동을 진행했습니다.
관리자가 신고 당한 유저를 blocked 처리하면 신고 테이블의 processed가 true로 자동 변환됩니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

