### PR TITLE
채팅 조회 시, 채팅 데이터를 역순으로 반환하도록 수정

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
+            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "rid", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 100, sort = "rid", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -71,8 +71,7 @@ public class RoomController implements RoomApi {
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @ModelAttribute FilteringCondition filteringCondition
     ) {
-        return new SuccessResponse<>(
-                roomService.findBySearchCondition(pageable, filteringCondition));
+        return new SuccessResponse<>(roomService.findBySearchCondition(pageable, filteringCondition));
     }
 
     // 참여 중인 모임방 조회
@@ -129,8 +128,7 @@ public class RoomController implements RoomApi {
             @PathVariable("roomId") Long roomId,
             @RequestBody FriendPhoneNumbersRequest request
     ) {
-        ChatRoom chatRoom = roomParticipationService.participate(memberDetails.getMember().getId(),
-                roomId, request);
+        ChatRoom chatRoom = roomParticipationService.participate(memberDetails.getMember().getId(), roomId, request);
         chatService.sendMessage(
                 chatRoom.getId(),
                 memberDetails.getMember(),
@@ -164,7 +162,6 @@ public class RoomController implements RoomApi {
             @PathVariable("roomId") Long roomId,
             @AuthenticationPrincipal CustomMemberDetails memberDetails
     ) {
-        return new SuccessResponse<>(
-                roomParticipationService.isMemberHost(roomId, memberDetails.getMember()));
+        return new SuccessResponse<>(roomParticipationService.isMemberHost(roomId, memberDetails.getMember()));
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #283

### 📝 작업 내용
- 채팅 조회 시, 채팅 데이터를 역순으로 반환하도록 수정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
간단한 변경사항이라 바로 머지합니다!
