### PR TITLE
채팅 메시지 전송 시의 FCM 알림 전송 실패 관련 예외처리 추가

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/application/ChatService.java
@@ -16,7 +16,6 @@ import com.gobongbob.festamate.global.NotificationService;
 import com.gobongbob.festamate.global.aop.CheckActiveUser;
 import com.gobongbob.festamate.global.response.exception.BadRequestException;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -57,17 +56,24 @@ public class ChatService {
         messagingTemplate.convertAndSend("/topic/chatRooms/" + chatRoomId, response);
 
         participants.forEach(participant -> {
-            String fcmToken = participant.getMember().getFcmToken(); // FCM 토큰 가져오기
+            String fcmToken = participant.getMember().getFcmToken();
             Long participantId = participant.getMember().getId();
+
             if (fcmToken != null) {
-                notificationService.sendNotification(
-                        fcmToken,
-                        "[Festamate!] 채팅 메시지가 도착했습니다!",
-                        member.getNickname() + ": " + message,
-                        participantId
-                );
+                try {
+                    notificationService.sendNotification(
+                            fcmToken,
+                            "[Festamate!] 채팅 메시지가 도착했습니다!",
+                            member.getNickname() + ": " + message,
+                            participantId
+                    );
+                } catch (RuntimeException e) {
+                    log.warn("FCM 전송 실패 (memberId: {}) - {}", participantId, e.getMessage());
+                    // 필요시: 유효하지 않은 토큰이면 여기서 제거도 가능
+                }
             }
         });
+
     }
 
     // 메시지 조회

--- a/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/MessageResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/dto/response/MessageResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public record MessageResponse(
         Long id,
+        Long memberId,
         String nickname,
         String message,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -15,6 +16,7 @@ public record MessageResponse(
     public static MessageResponse fromEntity(Message message) {
         return new MessageResponse(
                 message.getId(),
+                message.getSender().getId(),
                 message.getSender().getNickname(),
                 message.getMessage(),
                 message.getSendDate()

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
+            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "rid", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.ASC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/chat/presentation/ChatController.java
@@ -54,7 +54,7 @@ public class ChatController implements ChatApi {
     public SuccessResponse<Slice<MessageResponse>> findMessages(
             @AuthenticationPrincipal CustomMemberDetails memberDetails,
             @PathVariable("chatRoomId") Long chatRoomId,
-            @PageableDefault(size = 100, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 100, sort = "rid", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Slice<MessageResponse> messages = chatService.findMessagesByRoomId(
                 memberDetails.getMember().getId(),

--- a/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/presentation/RoomController.java
@@ -71,8 +71,7 @@ public class RoomController implements RoomApi {
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @ModelAttribute FilteringCondition filteringCondition
     ) {
-        return new SuccessResponse<>(
-                roomService.findBySearchCondition(pageable, filteringCondition));
+        return new SuccessResponse<>(roomService.findBySearchCondition(pageable, filteringCondition));
     }
 
     // 참여 중인 모임방 조회
@@ -129,8 +128,7 @@ public class RoomController implements RoomApi {
             @PathVariable("roomId") Long roomId,
             @RequestBody FriendPhoneNumbersRequest request
     ) {
-        ChatRoom chatRoom = roomParticipationService.participate(memberDetails.getMember().getId(),
-                roomId, request);
+        ChatRoom chatRoom = roomParticipationService.participate(memberDetails.getMember().getId(), roomId, request);
         chatService.sendMessage(
                 chatRoom.getId(),
                 memberDetails.getMember(),
@@ -164,7 +162,6 @@ public class RoomController implements RoomApi {
             @PathVariable("roomId") Long roomId,
             @AuthenticationPrincipal CustomMemberDetails memberDetails
     ) {
-        return new SuccessResponse<>(
-                roomParticipationService.isMemberHost(roomId, memberDetails.getMember()));
+        return new SuccessResponse<>(roomParticipationService.isMemberHost(roomId, memberDetails.getMember()));
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #285 

### 📝 작업 내용
- 채팅 메시지 전송 시의 FCM 알림 전송 실패 관련 예외처리 추가

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

