### PR TITLE
모임 참여에 대한 중복 요청 방지 로직 구현

### DIFF
--- a/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/member/application/MemberService.java
@@ -14,7 +14,6 @@ import com.gobongbob.festamate.domain.member.domain.Member;
 import com.gobongbob.festamate.domain.member.domain.Role;
 import com.gobongbob.festamate.domain.member.dto.request.MemberCreateRequest;
 import com.gobongbob.festamate.domain.member.dto.request.MemberFcmTokenRequest;
-import com.gobongbob.festamate.domain.member.dto.request.ProfileRegisterRequest;
 import com.gobongbob.festamate.domain.member.dto.request.ProfileUpdateRequest;
 import com.gobongbob.festamate.domain.member.dto.response.MemberProfileResponse;
 import com.gobongbob.festamate.domain.member.dto.response.MemberResponse;
@@ -207,7 +206,10 @@ public class MemberService {
 
     // 회원 존재 여부 확인
     public MemberExistResponse checkMemberExist(String phoneNumber) {
-        return new MemberExistResponse(memberRepository.existsByPhoneNumber(phoneNumber));
+        Member member = memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new BadRequestException(NO_MEMBER));
+
+        return new MemberExistResponse(memberRepository.existsByPhoneNumber(phoneNumber), member.getGender());
     }
 
     // 아래부터는 oauth2를 위한 메서드

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @Transactional(readOnly = true)
@@ -51,20 +53,7 @@ public class RoomParticipationService {
         participants.forEach(participant -> participateRoom(participant, room));
         if (room.isFull()) { // 방에 참여자가 다 찼을 때
             room.updateStatus(Status.MATCHED);
-
-            // **방 매칭 시 FCM 알림 전송**
-            room.getParticipants().forEach(participant -> {
-                String fcmToken = participant.getMember().getFcmToken(); // FCM 토큰 가져오기
-                Long participantId = participant.getMember().getId();
-                if (fcmToken != null) {
-                    notificationService.sendNotification(
-                            fcmToken,
-                            "방 매칭 완료",
-                            "방 매칭이 완료되었습니다: " + room.getTitle(),
-                            participantId
-                    );
-                }
-            });
+            sendNotifications(room);
         }
 
         return room.getChatRoom();
@@ -124,6 +113,26 @@ public class RoomParticipationService {
         members.add(member);
 
         return members;
+    }
+
+    private void sendNotifications(Room room) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                room.getParticipants().forEach(participant -> {
+                    String fcmToken = participant.getMember().getFcmToken();
+                    Long participantId = participant.getMember().getId();
+                    if (fcmToken != null) {
+                        notificationService.sendNotification(
+                                fcmToken,
+                                "방 매칭 완료",
+                                "방 매칭이 완료되었습니다: " + room.getTitle(),
+                                participantId
+                        );
+                    }
+                });
+            }
+        });
     }
 
     private void validateParticipation(Room room, List<Member> participants) {

--- a/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/application/RoomParticipationService.java
@@ -66,8 +66,6 @@ public class RoomParticipationService {
                 }
             });
         }
-      
-
 
         return room.getChatRoom();
     }

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/Room.java
@@ -21,6 +21,9 @@ public class Room {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private String title;
 
     private String place;

--- a/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/domain/RoomParticipant.java
@@ -9,6 +9,9 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "member_id"})
+)
 public class RoomParticipant {
 
     @Id

--- a/src/main/java/com/gobongbob/festamate/domain/room/dto/response/MemberExistResponse.java
+++ b/src/main/java/com/gobongbob/festamate/domain/room/dto/response/MemberExistResponse.java
@@ -1,7 +1,10 @@
 package com.gobongbob.festamate.domain.room.dto.response;
 
+import com.gobongbob.festamate.domain.member.domain.Gender;
+
 public record MemberExistResponse(
-        boolean exist
+        boolean exist,
+        Gender gender
 ) {
 
 }

--- a/src/main/java/com/gobongbob/festamate/global/config/WebClientConfig.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/WebClientConfig.java
@@ -1,4 +1,4 @@
-package com.gobongbob.festamate.global.config.webSocket;
+package com.gobongbob.festamate.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- close #300 

### 📝 작업 내용
#### 테이블 제약 조건 추가
- 한 모임에 같은 회원이 중복 참여할 수 있는 문제를 제약 조건 추가를 통해 해결했습니다.
  - `roomId`, `roomParticipantId` 에 대한 Unique 조건을 추가했습니다.

#### 낙관적 락 적용
- 한 모임에 동시에 여러 사람이 참여 요청을 보낼 때, 동시성 문제를 막으려면 락을 적용해야 합니다.
- 비관적 락은 성능 저하를 유발하기 때문에, version 필드 추가를 통해 낙관적 락을 적용했습니다.

#### FCM 알림 전송 시점 조정
- 현재 FCM 알림 전송 로직이 참여 요청 처리 중에 이미 진행되버려 요청이 실패했음에도 알림이 전송되버리는 문제가 있습니다.
- 알림 전송 시점을 트랜잭션 커밋 이후로 조정함으로써 해당 문제를 해결했습니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
궁금한 사항 있으면 질문 남겨주세요!
