### PR TITLE
인증번호 Redis 키 포맷 통일 및 코드 전송 2회 제한

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,7 +1,7 @@
 name: Java CD-Dev
 
 on:
-  push:
+  pull_request:
     branches: [ develop ]
     # 다음 파일들이 변경되었을 때는 워크플로우를 실행하지 않음
     paths-ignore:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,7 +1,7 @@
 name: Java CD-Prod
 
 on:
-  push:
+  pull_request:
     branches: [ main ] # 운영 브랜치 (main)
     paths-ignore:
       - '**.md'

--- a/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
@@ -20,14 +20,14 @@ public class TokyoSnsService {
     private final SnsClient snsClient; // AWS SNS 클라이언트
     private final StringRedisTemplate stringRedisTemplate;
 
-    // 인증 코드 유효 시간 (Duration 사용) - 예: 5분
+    // 인증 코드 유효 시간 (Duration 사용): 5분
     private static final Duration CODE_VALID_DURATION = Duration.ofMinutes(5);
     private static final String VERIFICATION_PREFIX = "verification:"; // Redis 키 접두사
 
     // 재전송 횟수 제한 관련 설정
     private static final String RETRY_COUNT_PREFIX = "retry_count:"; // 재전송 횟수 키 접두사
-    private static final int MAX_RETRY_COUNT = 2; // 하루 최대 재전송 횟수: 임시로 2개
-    private static final Duration RETRY_COUNT_VALID_DURATION = Duration.ofDays(1); // 재전송 횟수 카운트 유효 기간 (24시간)
+    private static final int MAX_RETRY_COUNT = 2; // 하루 최대 재전송 횟수: 2번
+    private static final Duration RETRY_COUNT_VALID_DURATION = Duration.ofDays(1); // 재전송 횟수 카운트 유효 기간: 24시간
 
     @Autowired
     public TokyoSnsService(SnsClient snsClient,

--- a/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
@@ -85,7 +85,7 @@ public class TokyoSnsService {
 
     // @Transactional 제거 (Redis 작업은 보통 단일 작업)
     public void verifyCode(String phoneNumber, String inputCode) {
-        String normalizedPhone = normalizePhoneNumber(phoneNumber); // 추가
+        String normalizedPhone = normalizePhoneNumber(phoneNumber);
         String redisKey = VERIFICATION_PREFIX + normalizedPhone;
         String retryCountKey = RETRY_COUNT_PREFIX + normalizedPhone;
 
@@ -108,7 +108,7 @@ public class TokyoSnsService {
     }
 
     public void removeVerificationInfo(String phoneNumber) {
-        String normalizedPhone = normalizePhoneNumber(phoneNumber); // 추가
+        String normalizedPhone = normalizePhoneNumber(phoneNumber);
         String redisKey = VERIFICATION_PREFIX + normalizedPhone;
         String retryCountKey = RETRY_COUNT_PREFIX + normalizedPhone;
         stringRedisTemplate.delete(redisKey);

--- a/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
+++ b/src/main/java/com/gobongbob/festamate/domain/sms/application/TokyoSnsService.java
@@ -26,7 +26,7 @@ public class TokyoSnsService {
 
     // 재전송 횟수 제한 관련 설정
     private static final String RETRY_COUNT_PREFIX = "retry_count:"; // 재전송 횟수 키 접두사
-    private static final int MAX_RETRY_COUNT = 5; // 하루 최대 재전송 횟수
+    private static final int MAX_RETRY_COUNT = 2; // 하루 최대 재전송 횟수: 임시로 2개
     private static final Duration RETRY_COUNT_VALID_DURATION = Duration.ofDays(1); // 재전송 횟수 카운트 유효 기간 (24시간)
 
     @Autowired
@@ -37,9 +37,10 @@ public class TokyoSnsService {
     }
 
     public void sendVerificationCode(String phoneNumber) {
-        String formattedPhone = formatToE164(phoneNumber);
-        String redisKey = VERIFICATION_PREFIX + phoneNumber;
-        String retryCountKey = RETRY_COUNT_PREFIX + phoneNumber;
+        String formattedPhone = formatToE164(phoneNumber); // 문자 발송용
+        String normalizedPhone = normalizePhoneNumber(phoneNumber); // Redis Key용
+        String redisKey = VERIFICATION_PREFIX + normalizedPhone;
+        String retryCountKey = RETRY_COUNT_PREFIX + normalizedPhone;
 
         // 1. 재전송 횟수 확인
         String currentRetryCountStr = stringRedisTemplate.opsForValue().get(retryCountKey);
@@ -84,8 +85,9 @@ public class TokyoSnsService {
 
     // @Transactional 제거 (Redis 작업은 보통 단일 작업)
     public void verifyCode(String phoneNumber, String inputCode) {
-        String redisKey = VERIFICATION_PREFIX + phoneNumber;
-        String retryCountKey = RETRY_COUNT_PREFIX + phoneNumber;
+        String normalizedPhone = normalizePhoneNumber(phoneNumber); // 추가
+        String redisKey = VERIFICATION_PREFIX + normalizedPhone;
+        String retryCountKey = RETRY_COUNT_PREFIX + normalizedPhone;
 
         // Redis에서 인증 코드 문자열 조회
         String storedCode = stringRedisTemplate.opsForValue().get(redisKey);
@@ -106,10 +108,16 @@ public class TokyoSnsService {
     }
 
     public void removeVerificationInfo(String phoneNumber) {
-        String redisKey = VERIFICATION_PREFIX + phoneNumber;
-        String retryCountKey = RETRY_COUNT_PREFIX + phoneNumber;
+        String normalizedPhone = normalizePhoneNumber(phoneNumber); // 추가
+        String redisKey = VERIFICATION_PREFIX + normalizedPhone;
+        String retryCountKey = RETRY_COUNT_PREFIX + normalizedPhone;
         stringRedisTemplate.delete(redisKey);
         stringRedisTemplate.delete(retryCountKey); // 정보 삭제 시 재시도 횟수 카운트도 함께 삭제
+    }
+
+    // 하이픈 제거
+    private String normalizePhoneNumber(String phoneNumber) {
+        return phoneNumber.replaceAll("-", "");
     }
 
     private String generateVerificationCode() {

--- a/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
+++ b/src/main/java/com/gobongbob/festamate/global/response/ResponseCode.java
@@ -47,7 +47,7 @@ public enum ResponseCode {
     KAKAO_API_REQUEST_FAILED(false, "카카오 API 요청에 실패했습니다."),
     AUTH_CODE_NOT_FOUND_OR_EXPIRED(false, "인증 요청이 존재하지 않거나 만료되었습니다."),
     AUTH_CODE_MISMATCH(false, "인증번호가 틀렸습니다."),
-    AUTH_REQUEST_DAILY_LIMIT_EXCEEDED(false, "하루 인증 요청 횟수를 초과했습니다.%s"),
+    AUTH_REQUEST_DAILY_LIMIT_EXCEEDED(false, "인증번호 전송 횟수를 초과했습니다. 하루 최대 2회까지만 전송할 수 있습니다.%s"),
 
     // 파일
     EMPTY_FILE(false, "파일이 비어있습니다."),


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#335 

### 📝 작업 내용
5번 -> 2번의 인증번호 전송으로 변경합니다. 즉, 첫 번째 시도 후 한 번 재전송 버튼을 누를 수 있으며 이후의 작업은 불가합니다. 즉, 한 명 당 인증번호 전송을 2회로 제한합니다.

테스트는 다음과 같이 진행합니다.

- [x] 두 번 재전송 후 세 번째 시도에서 24시간 제한 예외 발생 확인 -> 재전송 불가하도록 설정 완료
- [x] 첫 번째 재전송 코드가 아닌 두 번째 재전송 코드가 유효해야 함 -> 두 번째 재전송 코드만 유효함
- [x] 재전송할 때마다 인증 코드가 바뀌는 것 -> redis-cli에서 확인함

추가로 회원가입 중 학생증 OCR을 잘 읽어오는지 테스트도 진행합니다.
- [x] 메모장에 작성한 임의의 학생증 업로드 -> DB에 null로 들어가며 서비스 이용이 안 됨. 해당 필드 값이 null이라면 프론트엔드에서 다시 학생증 OCR 페이지로 리다이렉트 하도록 해야 할 것 같음

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

