### PR TITLE
CORS 헤더 추가

### DIFF
--- a/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
+++ b/src/main/java/com/gobongbob/festamate/global/config/SecurityConfig.java
@@ -159,7 +159,10 @@ public class SecurityConfig {
                 "Authorization",
                 "X-XSRF-token",
                 "Accept",
-                "Cookie"
+                "Cookie",
+                "Sec-CH-UA",
+                "Sec-CH-UA-Mobile",
+                "Sec-CH-UA-Platform"
         ));
 
         // 인증 정보 포함 여부


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#360 

### 📝 작업 내용
최신 크롬에서 자동으로 붙는 UA Client Hints 헤더 때문에 CORS 에러가 발생합니다.
이에 따라 헤더에 추가 작성합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

