### PR TITLE
Logrotate + S3를 활용한 로그 백업 시스템 도입

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -83,9 +83,10 @@ services:
       - FROM_NUMBER=${FROM_NUMBER}
 
 
-    volumes: # EC2 호스트 경로와 Docker 컨테이너 내부의 특정 경로를 연결(마운트)하는 역할
+    volumes:
       # EC2의 키 파일 경로: /home/ubuntu/festamate-firebase-key.json 컨테이너 내부 경로:/config/festamate-firebase-key.json
       - /home/ubuntu/festamate-firebase-key.json:/config/festamate-firebase-key.json:ro # 읽기 전용(ro)으로 마운트 권장
+      - /home/ubuntu/logs:/app/logs
     networks:
       - festamate-network
     depends_on:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<configuration>
+  <property name="LOG_PATH" value="/app/logs"/>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}/application.log</file>
+    <append>true</append>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+
+  <logger name="jdbc" level="OFF" additive="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="jdbc.sqlonly" level="DEBUG" additive="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="jdbc.sqltiming" level="OFF" additive="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.hibernate.SQL" level="DEBUG" additive="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="com.gobongbob.festamate.domain" level="DEBUG" additive="false">
+    <appender-ref ref="FILE"/>
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,12 @@
 <configuration>
   <property name="LOG_PATH" value="/app/logs"/>
 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${LOG_PATH}/application.log</file>
     <append>true</append>


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#377  

### 📝 작업 내용
- 스프링 어플리케이션 로그를 파일로 저장하도록 `logback-spring.xml` 작성
- 로그 파일을 인스턴스 내에 저장할 수 있도록 컨테이너 볼륨 설정 추가
- Logrotate 설정을 위해 관련 파일 작성 → `/etc/logrotate.d/myapp` 
- 로그 회전 후 S3 업로드를 위해 관련 스크립트 작성 →`/usr/local/bin/upload-festamate-logs-to-s3.sh`

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)

