### PR TITLE
기존 로그 백업 체계에 Logrotate 대신 Logback S3 Appender를 활용하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
     // CoolSMS
     implementation 'net.nurigo:sdk:4.2.7'
+
+    // Logback S3 Appender
+    implementation("io.github.dubtry:logback-s3-appender:3.0.0")
 }
 
 tasks.named('test') {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,4 @@
 <configuration>
-  <property name="LOG_PATH" value="/app/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
@@ -7,32 +6,25 @@
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${LOG_PATH}/application.log</file>
-    <append>true</append>
+  <appender name="S3" class="io.github.dubtry.logback.S3Appender">
+
+    <s3BucketName>festamate-logs</s3BucketName>
+    <s3FolderName>logs/festamate</s3FolderName>
+
+    <spoolEnabled>true</spoolEnabled>
+    <spoolDirectory>${LOG_PATH:-/app/logs}/s3-spool</spoolDirectory>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>application.%d{yyyy-MM-dd}.log</fileNamePattern>
+    </rollingPolicy>
+
     <encoder>
       <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="org.hibernate.SQL" level="OFF"/>
-  <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="OFF"/>
-  <logger name="jdbc" level="OFF"/>
-  <logger name="jdbc.sqlonly" level="OFF"/>
-  <logger name="jdbc.sqltiming" level="OFF"/>
-
-  <logger name="com.gobongbob.festamate" level="INFO" additivity="false">
-    <appender-ref ref="FILE"/>
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="WARN" additivity="false">
-    <appender-ref ref="FILE"/>
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
   <root level="INFO">
-    <appender-ref ref="FILE"/>
+    <appender-ref ref="S3"/>
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#380 

### 📝 작업 내용
- Logback S3 Appender 의존성 추가
- logback-spring.xml 내용 수정
  - 로그 파일을 서버 로컬에 직접 저장하지 않고, 자정마다 S3에 업로드하도록 추가
  - 기존 파일 저장 부분 제거

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

