### PR TITLE
Grafana Cloud + Loki + Alloy 를 활용한 로그 모니터링 시스템 구축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,8 +1,8 @@
 name: Java CD-Dev
 
 on:
-  pull_request:
-    #  push:
+  #  pull_request:
+  push:
     branches: [ develop ]
     # 다음 파일들이 변경되었을 때는 워크플로우를 실행하지 않음
     paths-ignore:

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
     // CoolSMS
     implementation 'net.nurigo:sdk:4.2.7'
+
+    // logstash-logback-encoder
+    implementation 'net.logstash.logback:logstash-logback-encoder:9.0'
 }
 
 tasks.named('test') {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -86,7 +86,7 @@ services:
     volumes:
       # EC2의 키 파일 경로: /home/ubuntu/festamate-firebase-key.json 컨테이너 내부 경로:/config/festamate-firebase-key.json
       - /home/ubuntu/festamate-firebase-key.json:/config/festamate-firebase-key.json:ro # 읽기 전용(ro)으로 마운트 권장
-      - /home/ubuntu/logs:/app/logs
+      - /var/log/spring-app:/app/logs
     networks:
       - festamate-network
     depends_on:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
   <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
-  <property name="LOG_PATH" value="/app/logs"/>
+  <property name="LOG_PATH" value="/var/log/spring-app"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,4 @@
 <configuration>
-  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
   <property name="LOG_PATH" value="/app/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -15,9 +14,7 @@
       <fileNamePattern>${LOG_PATH}/application-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
-    <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
   </appender>
 
   <root level="INFO">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
   <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
-  <property name="LOG_PATH" value="/home/ubuntu/logs"/>
+  <property name="LOG_PATH" value="/app/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,4 +1,5 @@
 <configuration>
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
   <property name="LOG_PATH" value="/home/ubuntu/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
   <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
-  <property name="LOG_PATH" value="/var/log/spring-app"/>
+  <property name="LOG_PATH" value="/app/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#382 

### 📝 작업 내용
#### 1. Grafana Cloud + Loki  + Alloy 도입
- 프리티어 인스턴스 사양상 Grafana + Loki + Promtail을 함꼐 운용할 수 없는 상황으로 인해 Grafana Cloud 도입
- Grafana Cloud는 별도 설치 없이 모니터링 서비스를 제공, 다만 로그 모니터링에 있어 최근 14일치 분량만 제공
- 로그 수집 기능만을 가진 Promtail 대신 매트릭, 로그, 트레이스 모두를 수집할 수 있는 Grafana 전용 에이전트 Alloy 도입

#### 2. Logback의 로그 저장 형식을 일반 텍스트에서 JSON으로 변경
- 기존 일반 텍스트 로그는 파싱 과정에서 일부 로그의 level이 유실되는 현상 발생
- 따라서 JSON 형식으로 level, logger_name, thread_name, message를 명확히 분리해서 출력하도록 수정
```bash
2025-11-02 01:02:40.265info{
  "@timestamp": "2025-11-02T01:02:40.11344231+09:00",
  "@version": "1",
  "message": "Completed initialization in 14 ms",
  "logger_name": "org.springframework.web.servlet.DispatcherServlet",
  "thread_name": "http-nio-8080-exec-2",
  "level": "INFO",
  "level_value": 20000
}
```
- Grafana Cloud 대시보드 출력시에는 개발자가 보기 편하게 다시 일반 텍스트 형식으로 변환

#### 3. 조건에 따른 알람 설정
- 어플리케이션에서 발생하는 에러에 대한 알림은 이미 Sentry에서 담당
- Grafana에서는 에러 발생 징후 및 인프라 관련 에러에 대한 알림을 제공
  - ex. 5분 동안 특정 에러 로그가 100건 이상 발생
  - ex. OutOfMemorryError 발생

### 📷 스크린샷 (선택)
#### Grafana Cloud 로그 모니터링 대시보드
<img width="1728" height="991" alt="스크린샷 2025-11-03 오후 6 34 21" src="https://github.com/user-attachments/assets/cd7f2fcb-de03-49b7-9d6d-a3c1960d39cc" />

#### Alloy 에이전트의 가벼움 (메모리 67.4M)
<img width="958" height="269" alt="스크린샷 2025-11-03 오후 6 38 36" src="https://github.com/user-attachments/assets/1717fa27-f6cb-490a-bd63-09e30b08cc09" />

#### Grafana 알림 전송 예시
<img width="550" height="158" alt="스크린샷 2025-11-03 오후 9 11 04" src="https://github.com/user-attachments/assets/53c3ecf9-3848-418c-b298-a95d02ba0af6" />
<img width="1406" height="762" alt="스크린샷 2025-11-03 오후 9 10 45" src="https://github.com/user-attachments/assets/62fe2720-8501-4668-830f-ba350183c471" />
<img width="730" height="676" alt="스크린샷 2025-11-03 오후 9 17 06" src="https://github.com/user-attachments/assets/92386b3f-0b54-40fc-8e9a-a0c6ec9356a8" />

### 💬 리뷰 요구사항 (선택)

