### PR TITLE
서버 마이그레이션 작업 

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -76,41 +76,44 @@ jobs:
       - name: Copy docker-compose-dev.yml to EC2
         uses: appleboy/scp-action@v0.1.7 # scp-action을 사용하여 파일을 EC2로 복사
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
           source: "docker-compose-dev.yml"  # Runner의 현재 작업 디렉토리에 있는 파일
-          target: "/home/ubuntu/"  # EC2 인스턴스의 대상 디렉토리 (파일이 복사될 위치)
+          target: "/home/ubuntu/festamate/"  # EC2 인스턴스의 대상 디렉토리 (파일이 복사될 위치)
 
       # 9) EC2에 배포
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
           script: |
             # 1. Docker Hub 로그인
             echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-            # 2. Firebase 키 파일 생성 (docker-compose.yml의 volume 경로와 일치해야 함)
+            
+            # 2. festamate 프로젝트 경로로 이동
+            cd /home/ubuntu/festamate/
+            
+            # 3. Firebase 키 파일 생성 (docker-compose.yml의 volume 경로와 일치해야 함)
             echo "${{ secrets.FESTAMATE_FIREBASE_KEY }}" > ./festamate-firebase-key.json
             
-            # EC2 내부에 .env 파일 생성 
+            # 4. EC2 내부에 .env 파일 생성 
             echo "${{ secrets.ENV }}" > .env
 
-            # 3. 최신 이미지 받기 (docker-compose.yml에 정의된 모든 서비스를 pull)
+            # 5. 최신 이미지 받기 (docker-compose.yml에 정의된 모든 서비스를 pull)
             # docker-compose.yml 파일에 명시된 이미지(예: gobongbab/festamate:latest, redis:6.2.4-alpine)가 
             # 이미 로컬에 존재한다면, docker compose up -d 명령어는 기본적으로 레지스트리를 확인하여 
             # 더 최신 버전이 있는지 검사하지 않고 로컬에 있는 기존 이미지를 사용하게 됩니다.
             # 따라서, docker compose pull 명령어를 사용하여 최신 이미지를 가져와야 합니다.
             docker compose -f docker-compose-dev.yml pull
 
-            # 4. 기존 컨테이너 내리기 (stop & remove)
+            # 6. 기존 컨테이너 내리기 (stop & remove)
             docker compose -f docker-compose-dev.yml down
 
-            # 5. 새 컨테이너 올리기 (백그라운드 실행, 현재 디렉토리의 .env 파일을 자동으로 읽음)
+            # 7. 새 컨테이너 올리기 (백그라운드 실행, 현재 디렉토리의 .env 파일을 자동으로 읽음)
             docker compose -f docker-compose-dev.yml up -d
 
-            # 6. 사용하지 않는 Docker 이미지 정리 (선택 사항)
+            # 8. 사용하지 않는 Docker 이미지 정리 (선택 사항)
             docker image prune -af

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -68,7 +68,7 @@ jobs:
       # 7) Docker Image 빌드 및 푸시
       - name: Build and push Docker Image
         run: |
-          docker build --platform=linux/arm64 -t ${{ secrets.DOCKER_USERNAME }}/festamate:latest .
+          docker build -f Dockerfile.dev --platform=linux/arm64 -t ${{ secrets.DOCKER_USERNAME }}/festamate:latest .
           docker push ${{ secrets.DOCKER_USERNAME }}/festamate:latest
 
       # 9) docker-compose-dev.yml 파일을 EC2로 복사

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,8 +1,8 @@
 name: Java CD-Dev
 
 on:
-  pull_request:
-    #  push:
+  #  pull_request:
+  push:
     branches: [ develop ]
     # 다음 파일들이 변경되었을 때는 워크플로우를 실행하지 않음
     paths-ignore:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -65,12 +65,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # 7) Docker Compose 빌드 및 푸시
-      - name: Build and push with Docker Compose
+      # 7) Docker Image 빌드 및 푸시
+      - name: Build and push Docker Image
         run: |
-          # 서비스 이름을 태그에 포함시켜 이미지 빌드 및 푸시 (운영 환경에 맞는 docker-compose 파일 사용)
-          docker compose -f docker-compose-dev.yml build
-          docker compose -f docker-compose-dev.yml push
+          docker build --platform=linux/arm64 -t ${{ secrets.DOCKER_USERNAME }}/festamate:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/festamate:latest
 
       # 9) docker-compose-dev.yml 파일을 EC2로 복사
       - name: Copy docker-compose-dev.yml to EC2

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,8 +1,8 @@
 name: Java CD-Dev
 
 on:
-  #  pull_request:
-  push:
+  pull_request:
+    #  push:
     branches: [ develop ]
     # 다음 파일들이 변경되었을 때는 워크플로우를 실행하지 않음
     paths-ignore:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # 개발용
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -90,7 +90,25 @@ services:
     networks:
       - festamate-network
     depends_on:
+      - mysql
       - redis-service
+
+  mysql:
+    image: mysql:8.0
+    restart: always
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: festamate
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+      MYSQL_ROOT_PASSWORD: ${DB_PASS}
+      TZ: Asia/Seoul
+      LANG: C.UTF-8
+    networks:
+      - festamate-network
 
   # Redis 캐시 서버 설정
   redis-service:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -86,7 +86,7 @@ services:
     volumes:
       # EC2의 키 파일 경로: /home/ubuntu/festamate-firebase-key.json 컨테이너 내부 경로:/config/festamate-firebase-key.json
       - /home/ubuntu/festamate/festamate-firebase-key.json:/config/festamate-firebase-key.json:ro # 읽기 전용(ro)으로 마운트 권장
-      - /var/log/spring-app:/app/logs
+      - /var/log/festamate-api:/app/logs
     networks:
       - festamate-network
     depends_on:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -141,7 +141,7 @@ services:
       - "12345:12345"
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./alloy-data:/var/lib/alloy
     command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy /etc/alloy/config.alloy
     depends_on:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -121,6 +121,34 @@ services:
     networks:
       - festamate-network
 
+  loki:
+    image: grafana/loki:3.0.0
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - ./loki-data:/loki
+    networks:
+      - festamate-network
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    user: root
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - ./alloy-data:/var/lib/alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy /etc/alloy/config.alloy
+    depends_on:
+      - loki
+    networks:
+      - festamate-network
+
 networks:
   festamate-network: # 서비스 간 통신을 위한 브릿지 네트워크
     driver: bridge

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -85,7 +85,7 @@ services:
 
     volumes:
       # EC2의 키 파일 경로: /home/ubuntu/festamate-firebase-key.json 컨테이너 내부 경로:/config/festamate-firebase-key.json
-      - /home/ubuntu/festamate-firebase-key.json:/config/festamate-firebase-key.json:ro # 읽기 전용(ro)으로 마운트 권장
+      - /home/ubuntu/festamate/festamate-firebase-key.json:/config/festamate-firebase-key.json:ro # 읽기 전용(ro)으로 마운트 권장
       - /var/log/spring-app:/app/logs
     networks:
       - festamate-network

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -99,7 +99,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - db-data:/var/lib/mysql
+      - ./mysql-data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: festamate
       MYSQL_USER: ${DB_USER}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -92,8 +92,8 @@ services:
     networks:
       - festamate-network
     depends_on:
-      - mysql
-      - redis-service
+      - db
+      - cache
 
   db:
     container_name: db

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,11 +1,13 @@
 # 개발용
 services:
   app:
-    container_name: festamate
+    container_name: app
     build:
       context: .
       dockerfile: Dockerfile.dev
     image: gobongbab/festamate:latest
+    labels:
+      - "logging.type=app"
     ports:
       - "8080:8080"
     restart: unless-stopped
@@ -93,8 +95,11 @@ services:
       - mysql
       - redis-service
 
-  mysql:
+  db:
+    container_name: db
     image: mysql:8.0
+    labels:
+      - "logging.type=db"
     restart: always
     ports:
       - "3306:3306"
@@ -111,9 +116,11 @@ services:
       - festamate-network
 
   # Redis 캐시 서버 설정
-  redis-service:
+  cache:
+    container_name: cache
     image: redis:latest
-    container_name: ${REDIS_CONTAINER_NAME}
+    labels:
+      - "logging.type=cache"
     restart: always
     ports:
       - "${REDIS_PORT}:6379"
@@ -122,8 +129,10 @@ services:
       - festamate-network
 
   loki:
-    image: grafana/loki:3.0.0
     container_name: loki
+    image: grafana/loki:3.0.0
+    labels:
+      - "logging.type=loki"
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -134,8 +143,10 @@ services:
       - festamate-network
 
   alloy:
-    image: grafana/alloy:latest
     container_name: alloy
+    image: grafana/alloy:latest
+    labels:
+      - "logging.type=alloy"
     user: root
     ports:
       - "12345:12345"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,9 +2,10 @@
   <property name="LOG_PATH" value="/app/logs"/>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
+    <!--    <encoder>-->
+    <!--      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>-->
+    <!--    </encoder>-->
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#390 

### 📝 작업 내용
#### 1. WAS 실행을 위한 핵심 파일 이동
- `docker-compose.yml`, `festamate-firebase-key.json` 이동

#### 2. 환경변수 수정 
- 서버 Host 정보 및 비밀번호 정보 수정
- `.env`의 카카오 로그인 BASE_URL

#### 3. 배포 스크립트 수정
- `docker-compose-dev.yml` 전송 목적지 경로 수정
- `firebase-key.json`, `.env` 생성 경로 수정

#### 4. DB 마이그레이션
- `docker-compose-dev.yml`에 MySQL 컨테이너 정보 추가
- `.env`의 DB 접속 정보 수정 -> ❗️ `DB_PASS` 값을 `00000000`으로 기입 (`'00000000'`일 가능성 있음)
- mysqldump 백업
- 신규 MySQL 컨테이너에 festamate 데이터베이스 import

#### 5. 최종 버그 수정 및 접속 테스트
- 라즈베리파이의 기존 MySQL 서버의 도커 네트워크를 festamate-network로 설정
- 라즈베리파이의 ARM 아키텍처에 따라 Dockerfile 빌드하도록 배포 스크립트 수정
- Spring의 MySQL 접속 URL 수정 (`mysql` → `docker-mysql-1`)
- Spring 컨테이너의 `festamate-firebase-key.json` 접근 볼륨 경로 수정
- [헬스체크 URL](https://pigeon.ddns.net/actuator/health)을 통한 정상 접속 확인 (`"status": "UP"`)

#### 6. 로그 백업/모니터링 시스템 마이그레이션
- 신규 서버 Crontab 스크립트 추가
- 기존 서버의 축적 로그를 신규 서버로 이동 
- `docker-compose-dev.yml`에 Loki, Alloy 컨테이너 정보 추가
- 신규 서버의 `config.alloy` 파일에 기존 서버 설정 내용 추가
- 기존, 신규 서버의 `config.alloy` 파일에 인스턴스 정보 관련 라벨링 추가

#### 7. 프론트엔드 API 요청 엔드포인트 일괄 수정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

